### PR TITLE
Fix incorrect permissions on directory creation

### DIFF
--- a/app/controllers/ModpackController.php
+++ b/app/controllers/ModpackController.php
@@ -263,7 +263,7 @@ class ModpackController extends BaseController {
 
 		/* Create new resources directory for modpack */
 		if (!file_exists($resourcePath)) {
-			mkdir($resourcePath, 0664, true);
+			mkdir($resourcePath, 0775, true);
 		}
 
 		/* If slug changed, move resources and delete old slug directory */


### PR DESCRIPTION
This would cause an exception when attemping to save modpack images
