### PR TITLE
Added Name Sorting on api level

### DIFF
--- a/app/controllers/ApiController.php
+++ b/app/controllers/ApiController.php
@@ -296,7 +296,7 @@ class APIController extends BaseController {
 			$modversions->each(function($modversion){
 				$modversion->name = $modversion->mod['name'];
 			});
-			$build->modversions = $modverions->sortBy('name');
+			$build->modversions = $modversions->sortBy('name');
 			if (empty($this->client))
 				Cache::put('modpack.'.$slug.'.build.'.$buildpass,$build,5);
 		}

--- a/app/controllers/ApiController.php
+++ b/app/controllers/ApiController.php
@@ -292,8 +292,8 @@ class APIController extends BaseController {
 			$build = Build::with('Modversions')
 						->where("modpack_id", "=", $modpack->id)
 						->where("version", "=", $build)->first();
-			$modverions = $build->modversions;
-			$modverions->each(function($modversion){
+			$modversions = $build->modversions;
+			$modversions->each(function($modversion){
 				$modversion->name = $modversion->mod['name'];
 			});
 			$build->modversions = $modverions->sortBy('name');

--- a/app/controllers/ApiController.php
+++ b/app/controllers/ApiController.php
@@ -292,6 +292,11 @@ class APIController extends BaseController {
 			$build = Build::with('Modversions')
 						->where("modpack_id", "=", $modpack->id)
 						->where("version", "=", $build)->first();
+			$modverions = $build->modversions;
+			$modverions->each(function($modversion){
+				$modversion->name = $modversion->mod['name'];
+			});
+			$build->modversions = $modverions->sortBy('name');
 			if (empty($this->client))
 				Cache::put('modpack.'.$slug.'.build.'.$buildpass,$build,5);
 		}


### PR DESCRIPTION
As suggested in Issue #228 this adds alphabetic sorting to mods in the API.
Mods get sorted by their Slug, who want's sorting by pretty name?