### PR TITLE
Unify actual requirements and message on "Edit Modpack" page

### DIFF
--- a/app/views/modpack/edit.blade.php
+++ b/app/views/modpack/edit.blade.php
@@ -76,7 +76,7 @@
 								</div>
 								@endif
 								<input type="file" name="background" id="background">
-								<span class="help-block">Required Size: 880x520</span>
+								<span class="help-block">Required Size: 900x600</span>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
In commit 543f2c6, the background resize code was corrected to 900x600 in `app/controllers/ModpackController.php` but the message in `app/views/modpack/edit.blade.php` still says "Required Size: 880x520".