### PR TITLE
Add Better Titles

### DIFF
--- a/app/views/layouts/master.blade.php
+++ b/app/views/layouts/master.blade.php
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>TechnicSolder {{ SOLDER_VERSION }}</title>
+    @section('title')
+      <title>TechnicSolder {{ SOLDER_VERSION }}</title>
+    @show
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{ HTML::script('js/jquery-1.11.1.min.js') }}
     {{ HTML::script('js/bootstrap.min.js') }}

--- a/app/views/mod/view.blade.php
+++ b/app/views/mod/view.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts/master')
 @section('title')
-    <title>{{ $mod->pretty_name }} - TechnicSolder</title>
+    <title>{{ empty($mod->pretty_name) ? $mod->name : $mod->pretty_name }} - TechnicSolder</title>
 @stop
 @section('content')
 <div class="page-header">

--- a/app/views/mod/view.blade.php
+++ b/app/views/mod/view.blade.php
@@ -1,4 +1,7 @@
 @extends('layouts/master')
+@section('title')
+    <title>{{ $mod->pretty_name }} - TechnicSolder</title>
+@stop
 @section('content')
 <div class="page-header">
 <h1>Mod Library</h1>
@@ -206,7 +209,7 @@ $(document).ready(function() {
 
 	/* Disabled for now, there is ample screen space that all we need to do is switch the tabs
 	        changing location is disorienting.
-	
+
 	$('#tabs a[href="#versions"]').click(function() {
 		window.location.hash = "#versions";
 	});

--- a/app/views/modpack/edit.blade.php
+++ b/app/views/modpack/edit.blade.php
@@ -1,4 +1,7 @@
 @extends('layouts/master')
+@section('title')
+    <title>{{ $modpack->name }} - TechnicSolder</title>
+@stop
 @section('content')
 <div class="page-header">
 <h1>Modpack Management - {{ $modpack->name }}</h1>

--- a/app/views/modpack/view.blade.php
+++ b/app/views/modpack/view.blade.php
@@ -1,11 +1,14 @@
 @extends('layouts/master')
+@section('title')
+    <title>{{ $modpack->name }} - TechnicSolder</title>
+@stop
 @section('content')
 <h1>Build Management - {{ $modpack->name }}</h1>
 <hr>
 <div class="panel panel-default">
 	<div class="panel-heading">
 		<div class="pull-right">
-			<a class="btn btn-primary btn-xs" href="{{ URL::to('modpack/add-build/'.$modpack->id) }}">Create New Build</a> 
+			<a class="btn btn-primary btn-xs" href="{{ URL::to('modpack/add-build/'.$modpack->id) }}">Create New Build</a>
 			<a class="btn btn-warning btn-xs" href="{{ URL::to('modpack/edit/'.$modpack->id) }}">Edit Modpack</a>
 		</div>
 	Build Management: {{ $modpack->name }}
@@ -20,7 +23,7 @@
 		@endif
 		<div class="table-responsive">
 		<table class="table table-striped table-bordered table-hover" id="dataTables">
-			<thead>	
+			<thead>
 				<tr>
 					<th>#</th>
 					<th>Build Number</th>

--- a/app/views/user/edit.blade.php
+++ b/app/views/user/edit.blade.php
@@ -1,4 +1,7 @@
 @extends('layouts/master')
+@section('title')
+    <title>{{ $user->username }} - TechnicSolder</title>
+@stop
 @section('content')
 <div class="page-header">
 <h1>User Management</h1>


### PR DESCRIPTION
Updating mods was really a hard thing to do when I had many tabs open
and couldn't find which was which. This simple change made it multiple
times better to organize my tabs.

Changing the title of the view can now be done by just adding the
section "title" to the page and adding the title tag inside of it.