### PR TITLE
Add Versions Buttons to Mod List View

### DIFF
--- a/app/views/mod/list.blade.php
+++ b/app/views/mod/list.blade.php
@@ -33,7 +33,7 @@
 					<th>Mod Name</th>
 					<th>Author</th>
 					<th>Website</th>
-					<th>Actions</th>
+					<th style="width: 150px;">Actions</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -47,7 +47,7 @@
 					@endif
 					<td>{{ !empty($mod->author) ? $mod->author : "N/A" }}</td>
 					<td>{{ !empty($mod->link) ? HTML::link($mod->link, $mod->link, array("target" => "_blank")) : "N/A" }}</td>
-					<td>{{ HTML::link('mod/view/'.$mod->id,'Manage', array("class" => "btn btn-xs btn-primary")) }}</td>
+					<td>{{ HTML::link('mod/view/'.$mod->id,'Manage', array("class" => "btn btn-xs btn-warning")) }} {{ HTML::link('mod/view/'.$mod->id.'#versions','Versions', array("class" => "btn btn-xs btn-primary")) }}</td>
 				</tr>
 			@endforeach
 		</table>


### PR DESCRIPTION
I found it helpful using a greasemonkey script while using Solder 0.3 to
include a versions button on the Mod List View.

This is helpful when updating mod versions for a modpack, less clicking when you got a big list of updates to install, you can hop straight to the version page as you rarely need the details page anyway once the mod is installed.

So I reimplemented the button properly for the current version of Solder.

The Manage button has been recoloured too so that it fits in with theme, matching the colour order on the Modpack Management View.

Using a width style directly on the th element was the best that I could come up with to keep the buttons on the same line (based off the amount of js being flung about ready to screw it up :) )