### PR TITLE
URI encode build version to prevent special chars from being dropped on post

### DIFF
--- a/app/views/modpack/view.blade.php
+++ b/app/views/modpack/view.blade.php
@@ -64,7 +64,7 @@
 $("input[name=recommended]").change(function() {
 	$.ajax({
 		type: "GET",
-		url: "{{ URL::to('modpack/modify/recommended?modpack='.$modpack->id) }}&recommended=" + $(this).val(),
+		url: "{{ URL::to('modpack/modify/recommended?modpack='.$modpack->id) }}&recommended=" + encodeURIComponent($(this).val()),
 		success: function (data) {
 			$("#success-ajax").stop(true, true).html(data.success).fadeIn().delay(2000).fadeOut();
 		}
@@ -74,7 +74,7 @@ $("input[name=recommended]").change(function() {
 $("input[name=latest]").change(function() {
 	$.ajax({
 		type: "GET",
-		url: "{{ URL::to('modpack/modify/latest?modpack='.$modpack->id) }}&latest=" + $(this).val(),
+		url: "{{ URL::to('modpack/modify/latest?modpack='.$modpack->id) }}&latest=" + encodeURIComponent($(this).val()),
 		success: function (data) {
 			$("#success-ajax").stop(true, true).html(data.success).fadeIn().delay(2000).fadeOut();
 		}


### PR DESCRIPTION
Fixes #255 

On update of the modpack recommended or latest builds, if the build version had a space or other special character the update would fail because the special characters were lost during the ajax post (even though the GUI presented a success message). By encoding the version number, the special characters are not lost during the ajax post.