### PR TITLE
Fix test cases

### DIFF
--- a/app/controllers/ModController.php
+++ b/app/controllers/ModController.php
@@ -183,7 +183,7 @@ class ModController extends BaseController {
 			}
 		}
 
-		return App::abort(404);
+		return Response::view('errors.missing', array(), 404);
 	}
 
 	public function anyAddVersion()
@@ -244,10 +244,10 @@ class ModController extends BaseController {
 			}
 		}
 
-		return App::abort(404);
+		return Response::view('errors.missing', array(), 404);
 	}
 
-	public function getDeleteVersion($ver_id = null)
+	public function anyDeleteVersion($ver_id = null)
 	{
 		if (Request::ajax())
 		{
@@ -274,7 +274,7 @@ class ModController extends BaseController {
 									));
 		}
 
-		return App::abort(404);
+		return Response::view('errors.missing', array(), 404);
 	}
 
 	private function mod_md5($mod, $version)

--- a/app/controllers/ModpackController.php
+++ b/app/controllers/ModpackController.php
@@ -579,10 +579,10 @@ class ModpackController extends BaseController {
 	public function anyModify($action = null)
 	{
 		if (!Request::ajax())
-			return App::abort('404');
+			return Response::view('errors.missing', array(), 404);
 
 		if (empty($action))
-			return Response::error('500');
+			return Response::view('errors.500', array(), 500);
 
 		switch ($action)
 		{

--- a/app/controllers/RemindersController.php
+++ b/app/controllers/RemindersController.php
@@ -37,7 +37,7 @@ class RemindersController extends Controller {
 	 */
 	public function getReset($token = null)
 	{
-		if (is_null($token)) App::abort(404);
+		if (is_null($token)) return Response::view('errors.missing', array(), 404);
 
 		return View::make('password.reset')->with('token', $token);
 	}

--- a/app/controllers/SolderController.php
+++ b/app/controllers/SolderController.php
@@ -57,7 +57,7 @@ class SolderController extends BaseController {
 			}
 		}
 
-		return App::abort(404);
+		return Response::view('errors.missing', array(), 404);
 	}
 
 	public function getCacheMinecraft() {
@@ -87,6 +87,6 @@ class SolderController extends BaseController {
 			}
 		}
 
-		return App::abort(404);
+		return Response::view('errors.missing', array(), 404);
 	}
 }

--- a/app/tests/ModTest.php
+++ b/app/tests/ModTest.php
@@ -116,7 +116,7 @@ class ModTest extends TestCase {
 
 	public function testModVersionAddPostNonAjax()
 	{
-		$this->call('POST', '/mod/add-version/', array("add-version"=>"1.0.0","md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3","mod-id"=>"1"));
+		$this->call('POST', '/mod/add-version/', array("add-version"=>"1.0.0","add-md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3","mod-id"=>"1"));
 		$this->assertResponseStatus(404);
 	}
 
@@ -139,7 +139,7 @@ class ModTest extends TestCase {
 	public function testModVersionAddPostEmptyModID()
 	{
 		//Fake an AJAX call.
-		$response = $this->call('POST', '/mod/add-version/', array("add-version"=>"1.0.0","md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3"),
+		$response = $this->call('POST', '/mod/add-version/', array("add-version"=>"1.0.0","add-md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3"),
 						array(), array("HTTP_X_REQUESTED_WITH"=>"XMLHttpRequest"));
 
 		$this->assertResponseOk();
@@ -155,7 +155,7 @@ class ModTest extends TestCase {
 	public function testModVersionAddPostInvalidModID()
 	{
 		//Fake an AJAX call.
-		$response = $this->call('POST', '/mod/add-version/', array("add-version"=>"1.0.0","md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3","mod-id"=>"1000000"),
+		$response = $this->call('POST', '/mod/add-version/', array("add-version"=>"1.0.0","add-md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3","mod-id"=>"1000000"),
 						array(), array("HTTP_X_REQUESTED_WITH"=>"XMLHttpRequest"));
 
 		$this->assertResponseOk();
@@ -171,7 +171,7 @@ class ModTest extends TestCase {
 	public function testModVersionAddPost()
 	{
 		//Fake an AJAX call.
-		$response = $this->call('POST', '/mod/add-version/', array("add-version"=>"1.0.0","md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3","mod-id"=>"1000000"),
+		$response = $this->call('POST', '/mod/add-version/', array("add-version"=>"1.0.0","add-md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3","mod-id"=>"1"),
 						array(), array("HTTP_X_REQUESTED_WITH"=>"XMLHttpRequest"));
 
 		$this->assertResponseOk();
@@ -191,7 +191,7 @@ class ModTest extends TestCase {
 	public function testModVersionAddPostMD5Fail()
 	{
 		//Fake an AJAX call.
-		$response = $this->call('POST', '/mod/add-version/', array("add-version"=>"1.0.0","md5"=>"","mod-id"=>"1"),
+		$response = $this->call('POST', '/mod/add-version/', array("add-version"=>"1.0.0","add-md5"=>"","mod-id"=>"1"),
 						array(), array("HTTP_X_REQUESTED_WITH"=>"XMLHttpRequest"));
 
 		$this->assertResponseOk();
@@ -213,7 +213,7 @@ class ModTest extends TestCase {
 	public function testModVersionRehashPostEmptyID()
 	{
 		//Fake an AJAX call.
-		$response = $this->call('POST', '/mod/add-version/', array("version-id"=>"","md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3"),
+		$response = $this->call('POST', '/mod/rehash/', array("version-id"=>"","md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3"),
 						array(), array("HTTP_X_REQUESTED_WITH"=>"XMLHttpRequest"));
 
 		$this->assertResponseOk();
@@ -229,7 +229,7 @@ class ModTest extends TestCase {
 	public function testModVersionRehashPostInvalidID()
 	{
 		//Fake an AJAX call.
-		$response = $this->call('POST', '/mod/add-version/', array("version-id"=>"10000000","md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3"),
+		$response = $this->call('POST', '/mod/rehash/', array("version-id"=>"10000000","md5"=>"bdbc6c6cc48c7b037e4aef64b58258a3"),
 						array(), array("HTTP_X_REQUESTED_WITH"=>"XMLHttpRequest"));
 
 		$this->assertResponseOk();

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,11 @@
 		"post-update-cmd": [
 			"php artisan clear-compiled",
 			"php artisan optimize"
+		],
+		"tests": [
+			"php artisan migrate:refresh --force",
+			"php artisan db:seed --class=\"TestSeeder\" --force",
+			"vendor/bin/phpunit --verbose"
 		]
 	},
 	"config": {


### PR DESCRIPTION
- Replaced App::abort() with Response::view() to prevent application from throwing unhanded exceptions
- Added tests script to composer so you can run 'composer run tests' to execute a full reset and test
- Fixed post vars for add-version tests (md5 should have been add-md5)
- Fixed call url for rehash tests
- Allow mod/delete-version to respond to both POST and GET