### PR TITLE
Refactor cURL init into a function

### DIFF
--- a/app/libraries/UrlUtils.php
+++ b/app/libraries/UrlUtils.php
@@ -3,22 +3,38 @@
 class UrlUtils {
 
 	/**
+	 * Initializes a cURL session with common options
+	 * @param  String $url
+	 * @param  int $timeout
+	 * @return resource
+	 */
+	private static function curl_init($url, $timeout)
+	{
+		$ch = curl_init($url);
+
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+		curl_setopt($ch, CURLOPT_USERAGENT, 'TechnicSolder/0.7 (https://github.com/TechnicPack/TechnicSolder)');
+		curl_setopt($ch, CURLOPT_MAXREDIRS, 5);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+
+		return $ch;
+	}
+
+	/**
 	 * Gets URL contents and returns them
 	 * @param  String $url
 	 * @return String
 	 */
 	public static function get_url_contents($url, $timeout)
 	{
-		$ch = curl_init($url);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-		curl_setopt($ch, CURLOPT_USERAGENT, 'TechnicSolder/0.7 (https://github.com/TechnicPack/TechnicSolder)');
-		curl_setopt($ch, CURLOPT_MAXREDIRS, 5);
-		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
-		curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+		$ch = self::curl_init($url, $timeout);
 
 		$data = curl_exec($ch);
-		
+
 		if(!curl_errno($ch)){
 			//check HTTP return code
 			$retcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -62,16 +78,10 @@ class UrlUtils {
 
 	public static function checkRemoteFile($url, $timeout)
 	{
-		$ch = curl_init($url);
+		$ch = self::curl_init($url, $timeout);
 
 		curl_setopt($ch, CURLOPT_NOBODY, true);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-		curl_setopt($ch, CURLOPT_MAXREDIRS, 5);
-		curl_setopt($ch, CURLOPT_USERAGENT, 'TechnicSolder/0.7 (https://github.com/TechnicPack/TechnicSolder)');
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
-		curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+
 		curl_exec($ch);
 
 		//check if there are any errors
@@ -107,7 +117,7 @@ class UrlUtils {
 		curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
 
 		$data = curl_exec($ch);
-		
+
 		if(!curl_errno($ch)){
 			//check HTTP return code
 			$retcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
This has the side effect of disabling SSL verification, which is required in servers that don't have a proper certificate store (like Windows), but might be undesirable for security purposes.