### PR TITLE
Made .panel-body show scrollbars on overflow, fixes #430.

### DIFF
--- a/public/css/solder.css
+++ b/public/css/solder.css
@@ -132,3 +132,7 @@ input[type=file] {
 	border-bottom: none;
 	margin: 0;
 }
+
+.panel-body {
+	overflow: auto;
+}


### PR DESCRIPTION
(Fixes #430)
This works on my mobile:
DROID4 (android 4.1.2)
running the stock browser at 960x540 qHD

To reproduce the issue in your desktop, just set `width: 33%;` on `#page-wrapper > row`.
(I had to do this because the chrome mobile-render-port wasn't zooming right.)

There are a handful of other mobile rendering issues but this doesn't seem to worsen any of them.

![desktop](http://i.imgur.com/XG6wbEM.png)
![mobile](http://i.imgur.com/nR1c63m.png)