### PR TITLE
Return cached results too!

### DIFF
--- a/app/controllers/ApiController.php
+++ b/app/controllers/ApiController.php
@@ -101,8 +101,8 @@ class APIController extends BaseController {
 				}
 				//usort($response['mod'], function($a, $b){return strcasecmp($a['name'], $b['name']);});
 				Cache::put('modlist',$response['mods'],5);
-				return Response::json($response);
 			}
+			return Response::json($response);
 		} else {
 			if (Cache::has('mod.'.$mod))
 			{


### PR DESCRIPTION
The location of the return statement in the recently merged #439 caused cached results for the mod list to never be output to the browser, this was missed by tests because the cached logic isn't covered (we only test these queries once, not twice)