### PR TITLE
Corrected the check to see if a mod had any versions.

### DIFF
--- a/app/views/mod/list.blade.php
+++ b/app/views/mod/list.blade.php
@@ -47,7 +47,7 @@
 							{{ HTML::link('mod/view/'.$mod->id, $mod->name) }}
 						@endif
 						<br/>
-						<b>Latest Version:</b> {{ !empty($mod->versions) ? $mod->versions->first()->version : "N/A" }}
+						<b>Latest Version:</b> {{ !$mod->versions->isEmpty() ? $mod->versions->first()->version : "N/A" }}
 					</td>
 					<td>{{ !empty($mod->author) ? $mod->author : "N/A" }}</td>
 					<td>{{ !empty($mod->link) ? HTML::link($mod->link, $mod->link, array("target" => "_blank")) : "N/A" }}</td>


### PR DESCRIPTION
This is caused because Laravel loads up a collection object even if it contains nothing.

Fixes #460.