### PR TITLE
Added the ability to clone modpacks entirely.

### DIFF
--- a/app/views/layouts/master.blade.php
+++ b/app/views/layouts/master.blade.php
@@ -89,6 +89,7 @@
                       @endforeach
                       <li><a href="{{ URL::to('modpack/list') }}">Modpack List</a></li>
                       <li><a href="{{ URL::to('modpack/create') }}">Add Modpack</a></li>
+                      <li><a href="{{ URL::to('modpack/clone') }}">Clone Modpack</a></li>
                   </ul>
                   <!-- /.nav-second-level -->
               </li>

--- a/app/views/modpack/clone.blade.php
+++ b/app/views/modpack/clone.blade.php
@@ -1,0 +1,111 @@
+@extends('layouts/master')
+@section('title')
+	<title>Clone Modpack - TechnicSolder</title>
+@stop
+@section('top')
+	<script src="{{{ asset('js/selectize.min.js') }}}"></script>
+	<link href="{{{ asset('css/selectize.css') }}}" rel="stylesheet">
+@endsection
+@section('content')
+	<div class="page-header">
+		<h1>Modpack Management</h1>
+	</div>
+	<div class="panel panel-default">
+		<div class="panel-heading">
+			Clone Modpack
+		</div>
+		<div class="panel-body">
+			@if ($errors->all())
+				<div class="alert alert-danger">
+					@foreach ($errors->all() as $error)
+						{{ $error }}<br />
+					@endforeach
+				</div>
+			@endif
+			{{ Form::open() }}
+			<div class="row">
+				<div class="col-md-6">
+					<div class="form-group">
+						<label for="source">Source Modpack</label>
+						<select class="form-control" name="source" id="source" placeholder="Select a modpack...">
+							<option value="">Select a modpack...</option>
+							@foreach($modpacks as $modpack)
+							<option value="{{ $modpack->slug }}">
+								{{ $modpack->name }}
+							</option>
+							@endforeach
+						</select>
+					</div>
+					<div class="form-group">
+						<label for="destination">Destination Modpack</label>
+						<input type="text" class="form-control" name="destination" id="destination">
+					</div>
+				</div>
+				<div class="col-md-6">
+					<p>Cloning a modpack will duplicate all of a modpack's builds and history into another modpack.</p>
+					<p class="alert alert-danger">If the destination modpack already exists all of its builds will be destroyed and replaced with copies of the source modpack's builds, only do this if you're certain you know what you're doing. Otherwise, create a new modpack by typing its name.</p>
+					<p>If you wish to link this modpack with an existing Technic Platform modpack, the slug must be identical to your slug on the Platform!</p>
+				</div>
+			</div>
+			{{ Form::submit('Clone Modpack', array('class' => 'btn btn-success')) }}
+			{{ HTML::link('modpack/list/', 'Go Back', array('class' => 'btn btn-primary')) }}
+			{{ Form::close() }}
+		</div>
+	</div>
+	<script type="text/javascript">
+		var $select = $("#source").selectize({
+			persist: false,
+			maxItems: 1,
+			create: true,
+			sortField: {
+				field: 'text',
+				direction: 'asc'
+			},
+		});
+		var source = $select[0].selectize;
+
+		var $select = $("#destination").selectize({
+			persist: false,
+			maxItems: 1,
+			create: true,
+			sortField: {
+				field: 'text',
+				direction: 'asc'
+			},
+		});
+		var destination = $select[0].selectize;
+
+		source.on('change', refreshDestinations);
+
+		$( document ).ready(function() {
+			refreshDestinations();
+		});
+
+		function refreshDestinations() {
+			destination.disable();
+			destination.clearOptions();
+			$.ajax({
+				type: "GET",
+				url: "{{ URL::to('api/modpack') }}/",
+				success: function (data) {
+					if (data.modpacks.length === 0){
+						$.jGrowl("No modpacks found.", { group: 'alert-warning' });
+						$("#destination").attr("placeholder", "No modpacks found...");
+					} else {
+						$.each(data.modpacks, function(slug, name) {
+							if ($("#source").val() != slug){
+								destination.addOption({value: slug, text: name});
+								destination.refreshOptions(false);
+							}
+						});
+						$("#destination").attr("placeholder", "Select a modpack...");
+					}
+				},
+				error: function (xhr, textStatus, errorThrown) {
+					$.jGrowl(textStatus + ': ' + errorThrown, { group: 'alert-danger' });
+				}
+			});
+			destination.enable();
+		}
+	</script>
+@endsection


### PR DESCRIPTION
Addresses #71
- Added a link in the sidebar to clone a modpack.
- Cloning to an existing modpack will overwrite it with the source's packs.
- Cloning to a nonexistent pack will create it.

I'm opening this up to talk about some of the concerns mentioned here and how they should be handled:
- There are no permissions associated with cloning.
- Destination list is loaded via JS therefore the modpacks have to be public even if the user has access to them. (Am I missing something here?)
- No modpack permissions are considered before handling cloning to/from anything.