### PR TITLE
Api extension - Authenticate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
+/.idea
 composer.phar
 composer.lock
 .DS_Store

--- a/app/controllers/ApiController.php
+++ b/app/controllers/ApiController.php
@@ -52,6 +52,16 @@ class APIController extends BaseController {
 				));
 	}
 
+	public function postLogin(){
+		$credentials['email'] = Input::get('email');
+		$credentials['password'] = Input::get('password');
+		if ( Auth::attempt($credentials, true)) {
+			return Response::make('Login success', 200);
+		} else {
+			return Response::make('Login fail', 403);
+		}
+	}
+
 	public function getModpack($modpack = null, $build = null)
 	{
 		if (empty($modpack))

--- a/app/tests/ApiTest.php
+++ b/app/tests/ApiTest.php
@@ -11,6 +11,28 @@ class ApiTest extends TestCase {
 		$this->assertEquals('{"api":"TechnicSolder","version":"'.SOLDER_VERSION.'","stream":"'.SOLDER_STREAM.'"}', $response->getContent());
 	}
 
+	public function testAuthorizedLogin()
+	{
+		$credentials = array(
+			'email' => 'admin@admin.com',
+			'password' => 'admin'
+		);
+
+		$this->call('POST', '/api/login', $credentials);
+		$this->assertResponseOk();
+	}
+
+	public function testUnauthorizedLogin()
+	{
+		$credentials = array(
+			'email' => 'test@admin.com',
+			'password' => 'ifail'
+		);
+
+		$this->call('POST', '/api/login', $credentials);
+		$this->assertResponseStatus(403);
+	}
+
 	public function testModpack()
 	{
 		$response = $this->call('GET', 'api/modpack/');


### PR DESCRIPTION
To authenticate POST `email` and `password` to `/api/login`. The app will then return `200` and session as well as remeber cookies if login was successful or `403` if there was an error.
First step for @Zlepper and #414 