### PR TITLE
Add response codes to the login

### DIFF
--- a/app/controllers/BaseController.php
+++ b/app/controllers/BaseController.php
@@ -40,9 +40,9 @@ class BaseController extends Controller {
 				Cache::put('update', true, 60);
 			}
 
-			return Redirect::to('dashboard/');
+			return Redirect::to('dashboard/', 200);
 		} else {
-			return Redirect::to('login')->with('login_failed',"Invalid Username/Password");
+			return Redirect::to('login', 403)->with('login_failed',"Invalid Username/Password");
 		}
 	}
 

--- a/app/tests/BaseTest.php
+++ b/app/tests/BaseTest.php
@@ -29,6 +29,7 @@ class BaseTest extends TestCase {
 		$response = $this->call('POST', '/login', $credentials);
 		$this->assertRedirectedTo('/login');
 		$this->assertSessionHas('login_failed');
+		$this->assertResponseStatus(403);
 	}
 
 	public function testAuthorizedLogin()
@@ -41,6 +42,7 @@ class BaseTest extends TestCase {
 
 		$response = $this->call('POST', '/login', $credentials);
 		$this->assertRedirectedTo('/dashboard');
+		$this->assertResponseStatus(200);
 	}
 
 	public function testIndex()


### PR DESCRIPTION
Will make it a lot easier for me in SolderHelper to understand exactly what happened. 
Instead of https://github.com/TechnicPack/TechnicSolder/pull/477

Not quite sure if it should be 403 or 401. 
I would say 403 since the login failed, the user didn't attempt to reach something that required auth, and therefor it shouldn't be 401.