### PR TITLE
Make it possible to create a pack that is visible at creation

### DIFF
--- a/app/controllers/ModpackController.php
+++ b/app/controllers/ModpackController.php
@@ -191,6 +191,7 @@ class ModpackController extends BaseController {
 		$modpack = new Modpack();
 		$modpack->name = Input::get('name');
 		$modpack->slug = Str::slug(Input::get('slug'));
+		$modpack->hidden = Input::get('hidden') ? false : true;
 		$modpack->icon_md5 = md5_file(public_path() . '/resources/default/icon.png');
 		$modpack->icon_url = URL::asset('/resources/default/icon.png');
 		$modpack->logo_md5 = md5_file(public_path() . '/resources/default/logo.png');


### PR DESCRIPTION
Another thing I need for solderhelper to work without hacks before the api is done. 
It keeps the current functionality where packs are created as hidden by the user, but you can send an additional parameter to the body and the pack will become visible.