### PR TITLE
Fix 404 on mod version deletion

### DIFF
--- a/app/views/mod/view.blade.php
+++ b/app/views/mod/view.blade.php
@@ -198,7 +198,7 @@ $('.delete').click(function(e) {
 	e.preventDefault();
 	$.ajax({
 		type: "GET",
-		url: "{{ URL::to('mod/delete-version/') }}" + $(this).attr('rel'),
+		url: "{{ URL::to('mod/delete-version') }}" +"/" + $(this).attr('rel'),
 		success: function (data) {
 			if (data.status == "success") {
 				$('.version[rel=' + data.version_id + ']').fadeOut();


### PR DESCRIPTION
to() removes the trailing slash, causing this line to generate 404 urls (/mod/delete-version3), for example.

Forcibly adding the trailing slash fixes the 404 and fixes issue #503