### PR TITLE
Fix 404 on mod version deletion

### DIFF
--- a/app/views/mod/view.blade.php
+++ b/app/views/mod/view.blade.php
@@ -198,7 +198,7 @@ $('.delete').click(function(e) {
 	e.preventDefault();
 	$.ajax({
 		type: "GET",
-		url: "{{ URL::to('mod/delete-version/') }}" + $(this).attr('rel'),
+		url: "{{ URL::to('mod/delete-version') }}" +"/" + $(this).attr('rel'),
 		success: function (data) {
 			if (data.status == "success") {
 				$('.version[rel=' + data.version_id + ']').fadeOut();

--- a/app/views/modpack/build/view.blade.php
+++ b/app/views/modpack/build/view.blade.php
@@ -121,6 +121,7 @@
 @section('bottom')
 <script type="text/javascript">
 var $select = $("#mod").selectize({
+			dropdownParent: "body",
 			persist: false,
 			maxItems: 1,
 			sortField: {
@@ -130,6 +131,7 @@ var $select = $("#mod").selectize({
 		});
 var mod = $select[0].selectize;
 var $select = $("#mod-version").selectize({
+			dropdownParent: "body",
 			persist: false,
 			maxItems: 1,
 			sortField: {


### PR DESCRIPTION
to() removes the trailing slash, causing this line to generate 404 urls (/mod/delete-version3), for example.

Forcibly adding the trailing slash fixes the 404 and fixes issue #503

Copy from PR #520 which was for the wrong branch