### PR TITLE
Improved config copying to respect an existing config directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	},
 	"scripts": {
 		"post-install-cmd": [
-			"php -r \"shell_exec((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') ? 'mkdir app\\config && copy app\\config-sample app\\config' : 'cp -r app/config-sample/. app/config');\"",
+			"php -r \"shell_exec((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') ? 'mkdir app\\config && copy app\\config-sample app\\config' : 'cp -nr app/config-sample/. app/config');\"",
 			"php -r \"copy('app/database-sample/production.sqlite', 'app/database/production.sqlite');\"",
 			"php -r \"chmod('app/storage', 0775);\"",
 			"php -r \"chmod('public/resources', 0775);\"",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	},
 	"scripts": {
 		"post-install-cmd": [
-			"php -r \"shell_exec((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') ? 'mkdir app\\config && copy app\\config-sample app\\config' : 'cp -r app/config-sample app/config');\"",
+			"php -r \"shell_exec((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') ? 'mkdir app\\config && copy app\\config-sample app\\config' : 'cp -r app/config-sample/. app/config');\"",
 			"php -r \"copy('app/database-sample/production.sqlite', 'app/database/production.sqlite');\"",
 			"php -r \"chmod('app/storage', 0775);\"",
 			"php -r \"chmod('public/resources', 0775);\"",


### PR DESCRIPTION
Currently, if an `app/config` directory already exists, `app/config-sample` would copy the directory so that it would leave `app/config/config-sample` and thus not copy properly.

The first commit changes this so it copies the _files_ so that this does not happen.

The second commit is one for backwards compatibility in case someone relied on the broken behaviour to store their modified config files, or perhaps prefer to have their own copy of the config and not allow changes to a default config value to go unnoticed when using a system like OpenShift (see below).

The point of this pull request was to allow something like this:

* app/
  - config/
    - production/
      - app.php
      - database.php
  - config-samples/
    - ...

in an environment like OpenShift. After this pull request you can simply pull this repository, add config changes to `app/config/production/` (or the equivalent env in use). Configs in this directory fall back to the files in the root `app/config/` so you only need to specify changes to configs rather than copying the whole thing. This is great for running under different environments.

In OpenShift, each commit to the app repository wipes the copy on the server and thus the config directory. If you have committed config changes in the structure above, you would be left with:

* app/
  - config/
    - production/
      - app.php
      - database.php
    - config-samples/
      - ...

All configs under `app/config/config-samples/` will not load (unless you set your env as such), and thus the default configs will not load. This pull requests fixes this.