### PR TITLE
Implement reset password functionality

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,6 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Libraries\UpdateUtils;
 
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Auth\Events\PasswordReset;
+
 class AuthController extends Controller
 {
     public function showLogin()
@@ -32,4 +38,63 @@ class AuthController extends Controller
             return redirect()->route('login')->with('login_failed', 'Invalid Username/Password');
         }
     }
+
+    public function showForgotPassword()
+    {
+        return view('auth.forgot-password');
+    }
+
+    public function postForgotPassword(Request $request)
+    {
+        $request->validate(['email' => 'required|email']);
+
+        $status = Password::sendResetLink(
+            $request->only('email')
+        );
+
+        switch ($status) {
+            case Password::RESET_LINK_SENT:
+                return back()->with(['success' => __($status)]);
+                break;
+
+            case Password::INVALID_USER:
+                return back()->with(['error' => __($status)]);
+                break;
+
+            default:
+                return back()->withErrors(['error' => __($status)]);
+                break;
+        }
+    }
+
+    public function showResetPassword($token)
+    {
+        return view('auth.reset-password', ['token' => $token]);
+    }
+
+    public function postResetPassword(Request $request)
+    {
+        $request->validate([
+            'token' => 'required',
+            'email' => 'required|email',
+            'password' => 'required|confirmed',
+        ]);
+
+        $status = Password::reset(
+            $request->only('email', 'password', 'password_confirmation', 'token'),
+            function ($user, $password) {
+                $user->forceFill([
+                    'password' => Hash::make($password)
+                ])->setRememberToken(Str::random(60));
+
+                $user->save();
+
+                event(new PasswordReset($user));
+            }
+        );
+
+        return $status === Password::PASSWORD_RESET
+                    ? redirect()->route('login')->with('status', __($status))
+                    : back()->withErrors(['email' => [__($status)]]);
+        }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,9 +4,16 @@ namespace App\Models;
 
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 
-class User extends Model implements AuthenticatableContract
+
+class User extends Model implements AuthenticatableContract,
+                                    CanResetPasswordContract
 {
+    use Notifiable, CanResetPassword;
+
     /**
      * The database table used by the model.
      *

--- a/database/migrations/2013_02_28_100000_create_password_resets_table.php
+++ b/database/migrations/2013_02_28_100000_create_password_resets_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('password_resets', function (Blueprint $table) {
+            $table->string('email')->index();
+            $table->string('token');
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('password_resets');
+    }
+};

--- a/public/css/login.css
+++ b/public/css/login.css
@@ -119,3 +119,7 @@ ul li {
   letter-spacing: 1.5px;
   cursor: pointer;
 }
+
+.text-center {
+  text-align: center;
+}

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -18,24 +18,18 @@
         <legend>
         Technic Solder
         </legend>
-        @if (Session::has('login_failed'))
+        @if (Session::has('error'))
           <ul class="notice errors">
-            <li>{{ Session::get('login_failed') }}</li>
+            <li>{{ Session::get('error') }}</li>
           </ul>
         @endif
-        @if (Session::has('logout') || Session::has('status'))
+        @if (Session::has('success'))
           <ul class="notice success">
-            <li>{{ Session::get('logout') }}</li>
-            <li>{{ Session::get('status') }}</li>
+            <li>{{ Session::get('success') }}</li>
           </ul>
         @endif
         <input type="text" name="email" class="input-block-level" placeholder="Email Address" size="30" autocomplete="off">
-        <input type="password" name="password" class="input-block-level" placeholder="Password" size="30" autocomplete="off">
-        <input name="login" type="submit" value="Log In">
-        <label class="checkbox"><input type="checkbox" name="remember" value="1">Remember me</label>
-        @if (Route::has('password.request'))
-          <p class="text-center"><a href="{{ route('password.request') }}">{{ __('Forgot Password?') }}</a></p>
-        @endif
+        <input name="login" type="submit" value="Reset password">
         <div class="footer">
           <p><a href="https://www.technicpack.net/">Powered by the Technic Platform</a></p>
         </div>

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -13,29 +13,24 @@
   </head>
   <body class="login">
     <img alt="Technic-logo" class="logo" height="70" src="{{ URL::asset('img/wrenchIcon.svg') }}">
-    <form class="vertical-form" method="post" action="">
+    <form class="vertical-form" method="post" action="{{ route('password.update') }}">
       <div style="margin:0;padding:0;display:inline;">
         <legend>
         Technic Solder
         </legend>
-        @if (Session::has('login_failed'))
+        @if (Session::has('errors'))
           <ul class="notice errors">
-            <li>{{ Session::get('login_failed') }}</li>
+            <li>{{ $errors->first('email') }}</li>
+            <li>{{ $errors->first('password') }}</li>
+            <li>{{ $errors->first('password_confirmation') }}</li>
           </ul>
         @endif
-        @if (Session::has('logout') || Session::has('status'))
-          <ul class="notice success">
-            <li>{{ Session::get('logout') }}</li>
-            <li>{{ Session::get('status') }}</li>
-          </ul>
-        @endif
-        <input type="text" name="email" class="input-block-level" placeholder="Email Address" size="30" autocomplete="off">
-        <input type="password" name="password" class="input-block-level" placeholder="Password" size="30" autocomplete="off">
-        <input name="login" type="submit" value="Log In">
-        <label class="checkbox"><input type="checkbox" name="remember" value="1">Remember me</label>
-        @if (Route::has('password.request'))
-          <p class="text-center"><a href="{{ route('password.request') }}">{{ __('Forgot Password?') }}</a></p>
-        @endif
+        @csrf
+        <input type="hidden" name="token" value="{{ $token }}">
+        <input type="text" class="input-block-level" name="email" placeholder="Email Address" required autofocus>
+        <input type="password" class="input-block-level" name="password" placeholder="Password" required autofocus>
+        <input type="password" class="input-block-level" name="password_confirmation" placeholder="Confirm Password" required autofocus>
+        <input name="login" type="submit" value="Reset Password">
         <div class="footer">
           <p><a href="https://www.technicpack.net/">Powered by the Technic Platform</a></p>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -97,3 +97,14 @@ Route::get('logout', function () {
 
     return Redirect::route('login')->with('logout', 'You have been logged out.');
 })->name('logout');
+
+Route::middleware('guest')->group(function () {
+    Route::get('forgot-password', [AuthController::class, 'showForgotPassword'])->name('password.request');
+    Route::post('forgot-password', [AuthController::class, 'postForgotPassword'])->name('password.email');
+
+    Route::get('reset-password/{token}', [AuthController::class, 'showResetPassword'])->name('password.reset');
+    Route::post('reset-password', [AuthController::class, 'postResetPassword'])->name('password.update');
+});
+
+
+


### PR DESCRIPTION
<!-- Put the issue number here -->

Fixes #176

<!--
You can check these checkboxes with an X or
by selecting them after you submit this pull-request
-->

- [x] Tested Changes using phpunit
- [x] Have read and followed the Contribution Guidelines

<!-- Put below what you have changed, and why it should be that way -->

This is my first contribution on Github so hopefully I'm doing it right. I've implemented basic forgot password functionality. It was discussed on Discord and also I found this suggestion in issues as well. There's a new link "Forgot password?" on login page. Existing user needs to put their e-mail address into reset password form and to that e-mail there's sent an e-mail with link for password reset. That means there must be set up SMTP server (or any other supported driver for sending e-mails). If someone wants to disable this functionality, they can just comment/remove "forgot-password" and "reset-password" routes. It will also remove "Forgot password" link from login page.

Because there's now more pages using login blade, maybe it'd be a good idea to create master blade for "guests" as well.