### PR TITLE
Fix version_manifest_v2.json versions extraction

### DIFF
--- a/app/Libraries/MinecraftUtils.php
+++ b/app/Libraries/MinecraftUtils.php
@@ -46,7 +46,7 @@ class MinecraftUtils
                 // The format is ['1.12.2' => ['version' => '1.12.2'], ...]
                 $versions = [];
 
-                foreach ($json as $mojangVersion) {
+                foreach ($json['versions'] as $mojangVersion) {
                     if ($mojangVersion['type'] !== 'release') {
                         continue;
                     }


### PR DESCRIPTION
The versions from https://launchermeta.mojang.com/mc/game/version_manifest_v2.js are now under {"versions":[]} field

https://launchermeta.mojang.com/mc/game/version_manifest_v2.json

![image](https://github.com/user-attachments/assets/f2f0704d-f59a-466d-a656-561edeb0dd87)


<!-- Put the issue number here -->

Fixes #

<!--
You can check these checkboxes with an X or
by selecting them after you submit this pull-request
-->

- [x] Tested Changes using phpunit
- [ ] Have read and followed the Contribution Guidelines

<!-- Put below what you have changed, and why it should be that way -->
