### PR TITLE
Update compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,39 +1,39 @@
+version: "3.3"
+
 services:
   nginx:
     image: nginx
     restart: always
     depends_on:
       - solder
-    links:
-      - solder
     ports:
       - "80:80"
     volumes:
       - ./docker/default.conf:/etc/nginx/conf.d/default.conf
-      - .:/var/www/html
+      - ./www:/var/www/html
+      
   solder:
     image: solder
     restart: always
     depends_on:
       - mysql
       - redis
-    links:
-      - mysql:mysql
-      - redis:redis
     volumes:
-      - .:/var/www/html
+      - ./www:/var/www/html
+
   mysql:
     image: mariadb
     restart: always
     environment:
-      - MYSQL_DATABASE=solder
-      - MYSQL_USER=solder
-      - MYSQL_PASSWORD=solder
-      - MYSQL_RANDOM_ROOT_PASSWORD=yes
-      - MYSQL_TCP_PORT=4306
-      - MYSQL_UNIX_PORT=4306
+      MYSQL_DATABASE: solder
+      MYSQL_USER: solder
+      MYSQL_PASSWORD: solder
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+    ports:
+      - "4306:3306"
     volumes:
       - ./docker/mysql:/var/lib/mysql
+
   redis:
     image: redis
     restart: always


### PR DESCRIPTION
Fixes the compose.yml for docker. 

There isn't an issue open as far as I know but I just encountered following error myself:
`ERROR: The Compose file './compose-setup.yml' is invalid because:
Unsupported config option for services: 'setup'
docker@crackscout /TechnicSolder # docker-compose -f compose-setup.yml up
ERROR: The Compose file './compose-setup.yml' is invalid because:
Unsupported config option for services: 'setup'
docker@crackscout /echnicSolder # docker-compose -f compose-setup.yml
Define and run multi-container applications with Docker.
`
so I fixed it.

<!--
You can check these checkboxes with an X or
by selecting them after you submit this pull-request
-->

- [ X ] Tested Changes using phpunit (tested it with docker)
- [ X ] Have read and followed the Contribution Guidelines

<!-- Put below what you have changed, and why it should be that way -->
The old compose-setup.yml and compose.yml was outdate and would simply not work. I just wanted to install Solder using the given docker files and commands - resulting in multiple syntax and version errors.
Now you can just run with `docker-compose -f compose.yml up`
The actual way to do it would be removing the compose-setup.yml entirely and just provide a docker-compose.yml with the contents I provided in this pull request.  
