### PR TITLE
chore: add npm supply-chain hardening config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,11 @@
+# Supply-chain hardening.
+
+# Block dependency lifecycle scripts (preinstall/install/postinstall/prepare).
+# This project defines none of its own; only fsevents (macOS-only, optional) is
+# affected, and it degrades gracefully to file-watch polling.
+ignore-scripts=true
+
+# Dependency cooldown: only install versions published more than 7 days ago, so
+# malicious or yanked releases are caught by the ecosystem before entering our
+# tree. Does not affect `npm ci` (locked installs) or Renovate security PRs.
+min-release-age=7

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   ],
   "configMigration": true,
   "rangeStrategy": "bump",
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "matchManagers": ["composer"],


### PR DESCRIPTION
## What

Hardens the npm dependency supply chain with a committed `.npmrc` plus a matching Renovate cooldown.

**`.npmrc` (new)**
- `ignore-scripts=true` — blocks dependency lifecycle scripts (install/postinstall/prepare). This project defines none of its own; only the optional, macOS-only `fsevents` binding is affected, and it degrades gracefully to file-watch polling.
- `min-release-age=7` — installs only versions published more than 7 days ago, so malicious or yanked releases are caught before entering the tree. Does **not** affect `npm ci` (locked installs).

**`renovate.json`**
- `minimumReleaseAge: "7 days"` mirrors the cooldown so update PRs wait out the window. Renovate's `vulnerabilityAlerts` default already exempts security PRs, so fixes are not delayed.

## Verification
- `npm config get ignore-scripts min-release-age` → `true` / `7`
- `npm ci && npm run build` succeed with scripts disabled