### PR TITLE
refactor: authorize modversion writes through write abilities

### DIFF
--- a/app/Http/Controllers/Api/ModversionController.php
+++ b/app/Http/Controllers/Api/ModversionController.php
@@ -80,7 +80,7 @@ class ModversionController extends Controller
 
     public function update(Request $request, string $slug, string $version): JsonResponse
     {
-        $this->authorize('create', Modversion::class);
+        $this->authorize('update', Modversion::class);
 
         $mod = Mod::where('name', $slug)->first();
 

--- a/app/Http/Controllers/ModController.php
+++ b/app/Http/Controllers/ModController.php
@@ -175,7 +175,7 @@ class ModController extends Controller
             abort(404);
         }
 
-        $this->authorize('viewAny', Mod::class);
+        $this->authorize('update', Modversion::class);
 
         $md5 = Request::input('md5');
         $ver_id = Request::input('version-id');
@@ -242,7 +242,7 @@ class ModController extends Controller
             abort(404);
         }
 
-        $this->authorize('viewAny', Mod::class);
+        $this->authorize('create', Modversion::class);
 
         $mod_id = Request::input('mod-id');
         $md5 = Request::input('add-md5');
@@ -325,7 +325,7 @@ class ModController extends Controller
             abort(404);
         }
 
-        $this->authorize('create', Modversion::class);
+        $this->authorize('update', Modversion::class);
 
         $ver = Modversion::find($ver_id);
         if (empty($ver)) {
@@ -352,7 +352,7 @@ class ModController extends Controller
             abort(404);
         }
 
-        $this->authorize('viewAny', Mod::class);
+        $this->authorize('delete', Modversion::class);
 
         if (empty($ver_id)) {
             return response()->json([

--- a/app/Policies/ModversionPolicy.php
+++ b/app/Policies/ModversionPolicy.php
@@ -11,6 +11,11 @@ class ModversionPolicy
         return $user->permission->mods_manage;
     }
 
+    public function update(User $user): bool
+    {
+        return $user->permission->mods_manage;
+    }
+
     public function delete(User $user): bool
     {
         return $user->permission->mods_manage;

--- a/tests/Unit/AuthorizationTest.php
+++ b/tests/Unit/AuthorizationTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Unit;
 
+use App\Models\Mod;
 use App\Models\Modpack;
+use App\Models\Modversion;
 use App\Models\User;
 use App\Models\UserPermission;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -301,5 +303,113 @@ final class AuthorizationTest extends TestCase
         $this->get('/key/list')->assertRedirect('/dashboard');
         $this->get('/client/list')->assertRedirect('/dashboard');
         $this->get('/user/list')->assertRedirect('/dashboard');
+    }
+
+    // --- Mod version write authorization ---
+    //
+    // These AJAX endpoints mutate modversions and must be gated by `mods_manage`
+    // (via ModversionPolicy), not merely by the `mods_create` capability. A user
+    // who can create mods but cannot manage them must be denied. The endpoints
+    // abort(404) on non-AJAX requests, so the AJAX header is required to reach
+    // the authorization gate (which then renders 403 for JSON requests).
+
+    private function seedModVersion(): Modversion
+    {
+        $mod = Mod::create(['name' => 'authztest', 'pretty_name' => 'AuthZ Test']);
+
+        return Modversion::create([
+            'mod_id' => $mod->id,
+            'version' => '1.0',
+            'md5' => str_repeat('a', 32),
+            'filesize' => 100,
+        ]);
+    }
+
+    public function test_add_version_denied_without_mods_manage(): void
+    {
+        $user = $this->createUserWithPermissions(['mods_create' => true]);
+        $version = $this->seedModVersion();
+
+        $this->actingAs($user)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->post('/mod/add-version', [
+                'mod-id' => $version->mod_id,
+                'add-version' => '2.0',
+                'add-md5' => str_repeat('c', 32),
+            ])
+            ->assertRedirect('/dashboard');
+
+        $this->assertDatabaseMissing('modversions', [
+            'mod_id' => $version->mod_id,
+            'version' => '2.0',
+        ]);
+    }
+
+    public function test_rehash_denied_without_mods_manage(): void
+    {
+        $user = $this->createUserWithPermissions(['mods_create' => true]);
+        $version = $this->seedModVersion();
+
+        $this->actingAs($user)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->post('/mod/rehash', [
+                'version-id' => $version->id,
+                'md5' => str_repeat('b', 32),
+            ])
+            ->assertRedirect('/dashboard');
+    }
+
+    public function test_update_version_denied_without_mods_manage(): void
+    {
+        $user = $this->createUserWithPermissions(['mods_create' => true]);
+        $version = $this->seedModVersion();
+
+        $this->actingAs($user)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->post('/mod/update-version/'.$version->id, ['notes' => 'tampered'])
+            ->assertRedirect('/dashboard');
+    }
+
+    public function test_delete_version_denied_without_mods_manage(): void
+    {
+        $user = $this->createUserWithPermissions(['mods_create' => true]);
+        $version = $this->seedModVersion();
+
+        $this->actingAs($user)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->post('/mod/delete-version/'.$version->id)
+            ->assertRedirect('/dashboard');
+
+        $this->assertModelExists($version);
+    }
+
+    public function test_add_version_allowed_with_mods_manage(): void
+    {
+        $user = $this->createUserWithPermissions(['mods_manage' => true]);
+        $version = $this->seedModVersion();
+
+        $this->actingAs($user)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->post('/mod/add-version', [
+                'mod-id' => $version->mod_id,
+                'add-version' => '2.0',
+                'add-md5' => str_repeat('c', 32),
+            ])
+            ->assertOk()
+            ->assertJson(['status' => 'success']);
+    }
+
+    public function test_delete_version_allowed_with_mods_manage(): void
+    {
+        $user = $this->createUserWithPermissions(['mods_manage' => true]);
+        $version = $this->seedModVersion();
+
+        $this->actingAs($user)
+            ->withHeaders(['X-Requested-With' => 'XMLHttpRequest'])
+            ->post('/mod/delete-version/'.$version->id)
+            ->assertOk()
+            ->assertJson(['status' => 'success']);
+
+        $this->assertModelMissing($version);
     }
 }


### PR DESCRIPTION
## What

The web modversion AJAX handlers (`anyRehash`, `anyAddVersion`,
`anyUpdateVersion`, `anyDeleteVersion`) authorized mutations through the
`viewAny` **read** ability, and the API `ModversionController::update`
reused the `create` ability. This re-points each at the semantically
correct `Modversion` ability (`create` / `update` / `delete`) so the web
and API surfaces authorize identically.

## Why

Authorizing a write through a read ability is fragile: if
`ModversionPolicy` were later tightened (e.g. delete requires
`mods_delete`), the web path would silently keep using `viewAny` and
skip the new check. This aligns the web AJAX surface with the API.

## Behavior change

**None.** Every mod/modversion ability resolves to `mods_manage`, so the
effective permission required by each endpoint is unchanged (confirmed by
stashing the change and re-running).

Also adds `ModversionPolicy::update()`, which was previously missing —
that gap is why the controllers were overloading `create` for updates.

## Tests

New "Mod version write authorization" section in `AuthorizationTest`:
4 deny tests (a `mods_create`-only user is redirected and the row is
untouched) + 2 allow tests (a `mods_manage` user succeeds), locking each
endpoint to `mods_manage`.

- `AuthorizationTest`: **40 passed** (89 assertions), incl. 6 new
- `ModTest` + `ApiAuthorizationTest` + `ApiWriteTest`: 97 passed, 2 failed
  — both **pre-existing**, fixture-dependent (md5-from-file tests needing
  mod zips at `/var/www/mods.solder.test/`), proven independent via
  `git stash` + rerun
- Pint clean
