### PR TITLE
fix: harden authentication and user administration

### DIFF
--- a/.claude/rules/docker.md
+++ b/.claude/rules/docker.md
@@ -9,8 +9,7 @@ This project ships two separate Compose stacks. They are NOT layered; each runs 
 
 - Start: `docker compose -f compose.dev.yml up -d`
 - Stop: `docker compose -f compose.dev.yml down`
-- Run commands: `docker compose exec -T solder <cmd>` works once the stack is up (this is the
-  running container the bare `docker compose exec` lines in laravel.md and testing.md target).
+- Run commands: `docker compose -f compose.dev.yml exec -T solder <cmd>` works once the stack is up.
 
 ## Never do this
 

--- a/.claude/rules/docker.md
+++ b/.claude/rules/docker.md
@@ -1,0 +1,23 @@
+# Docker
+
+This project ships two separate Compose stacks. They are NOT layered; each runs on its own.
+
+- Development: `compose.dev.yml` (PostgreSQL). The standalone stack for all local work.
+- Production: `compose.yml` (MariaDB). The shipped self-host stack; not for development.
+
+## Development workflow
+
+- Start: `docker compose -f compose.dev.yml up -d`
+- Stop: `docker compose -f compose.dev.yml down`
+- Run commands: `docker compose exec -T solder <cmd>` works once the stack is up (this is the
+  running container the bare `docker compose exec` lines in laravel.md and testing.md target).
+
+## Never do this
+
+- Never run `docker compose up` with no `-f`. That starts the production MariaDB stack.
+- Never merge the two files (`-f compose.yml -f compose.dev.yml`). The merge pulls MariaDB and
+  the production env-injection block into dev, which: crashes the app (pgsql driver hitting
+  MariaDB), runs two databases at once, and breaks test isolation (tests hit PostgreSQL instead
+  of stock sqlite; CSRF and config defaults misbehave).
+- The dev `solder` service injects no env vars by design; it reads the mounted `.env`, and tests
+  use stock `phpunit.xml` plus `.env.testing` (sqlite). Do not add an `environment:` block to it.

--- a/.claude/rules/laravel.md
+++ b/.claude/rules/laravel.md
@@ -1,22 +1,22 @@
 # Laravel
 
-- Use `docker compose exec -T solder php artisan make:` to create new files (migrations, controllers, models, etc.). Pass `--no-interaction` and the correct `--options`.
-- List available commands: `docker compose exec -T solder php artisan list`. Check parameters: `docker compose exec -T solder php artisan [command] --help`.
-- For generic PHP classes: `docker compose exec -T solder php artisan make:class`.
-- When creating models, also create factories and seeders. Ask the user about additional options via `docker compose exec -T solder php artisan make:model --help`.
+- Use `docker compose -f compose.dev.yml exec -T solder php artisan make:` to create new files (migrations, controllers, models, etc.). Pass `--no-interaction` and the correct `--options`.
+- List available commands: `docker compose -f compose.dev.yml exec -T solder php artisan list`. Check parameters: `docker compose -f compose.dev.yml exec -T solder php artisan [command] --help`.
+- For generic PHP classes: `docker compose -f compose.dev.yml exec -T solder php artisan make:class`.
+- When creating models, also create factories and seeders. Ask the user about additional options via `docker compose -f compose.dev.yml exec -T solder php artisan make:model --help`.
 - For APIs, default to Eloquent API Resources and API versioning unless existing routes don't — follow application convention.
 - Prefer named routes and the `route()` function for links.
 
 ## Routes & Config
 
-- Inspect routes: `docker compose exec -T solder php artisan route:list` (filter: `--method=GET`, `--name=users`, `--path=api`, `--except-vendor`, `--only-vendor`).
-- Read config: `docker compose exec -T solder php artisan config:show app.name`, or read config files directly from `config/`.
+- Inspect routes: `docker compose -f compose.dev.yml exec -T solder php artisan route:list` (filter: `--method=GET`, `--name=users`, `--path=api`, `--except-vendor`, `--only-vendor`).
+- Read config: `docker compose -f compose.dev.yml exec -T solder php artisan config:show app.name`, or read config files directly from `config/`.
 - Check environment variables by reading `.env` directly.
 
 ## Tinker
 
 - Use for debugging/testing in app context. Don't create models without approval — prefer tests with factories. Prefer existing Artisan commands over custom tinker code.
-- Always single quotes to prevent shell expansion: `docker compose exec -T solder php artisan tinker --execute 'Your::code();'`
+- Always single quotes to prevent shell expansion: `docker compose -f compose.dev.yml exec -T solder php artisan tinker --execute 'Your::code();'`
   - Double quotes for PHP strings inside: `'User::where("active", true)->count();'`
 
 ## Vite Error

--- a/.claude/rules/pint.md
+++ b/.claude/rules/pint.md
@@ -1,4 +1,4 @@
 # Laravel Pint
 
-- After modifying PHP files, run `docker compose exec -T solder ./vendor/bin/pint --dirty --format agent` before finalizing changes.
+- After modifying PHP files, run `docker compose -f compose.dev.yml exec -T solder ./vendor/bin/pint --dirty --format agent` before finalizing changes.
 - Do not use `--test`; just run pint to fix formatting issues.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -2,7 +2,7 @@
 
 - Every change must be programmatically tested. Write a new test or update an existing test, then run it.
 - Do not create verification scripts or tinker when tests cover the functionality. Unit and feature tests are more important.
-- All tests must be PHPUnit classes. Use `docker compose exec -T solder php artisan make:test --phpunit {name}` to create a new test. Pass `--unit` for unit tests. Most tests should be feature tests.
+- All tests must be PHPUnit classes. Use `docker compose -f compose.dev.yml exec -T solder php artisan make:test --phpunit {name}` to create a new test. Pass `--unit` for unit tests. Most tests should be feature tests.
 - If you see a test using "Pest", convert it to PHPUnit.
 - Use factories for test models. Check for custom factory states before manual setup.
 - Faker: follow existing conventions (`$this->faker` vs `fake()`).
@@ -13,6 +13,6 @@
 ## Running Tests
 
 - Run the minimal number of tests using an appropriate filter before finalizing.
-- All tests: `docker compose exec -T solder php artisan test --compact`
-- Single file: `docker compose exec -T solder php artisan test --compact tests/Feature/ExampleTest.php`
-- Specific test: `docker compose exec -T solder php artisan test --compact --filter=testName` (recommended)
+- All tests: `docker compose -f compose.dev.yml exec -T solder php artisan test --compact`
+- Single file: `docker compose -f compose.dev.yml exec -T solder php artisan test --compact tests/Feature/ExampleTest.php`
+- Specific test: `docker compose -f compose.dev.yml exec -T solder php artisan test --compact --filter=testName` (recommended)

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -115,7 +115,7 @@ class UserController extends Controller
             // Proof of identity for a session takeover, not proof of the target's
             // password: `current_password:web` checks the *actor*, so a manager
             // resetting someone else's password confirms their own.
-            $rules['current_password'] = ['required', 'current_password:web'];
+            $rules['current_password'] = ['bail', 'required', 'string', 'current_password:web'];
             $rules['password1'] = [Password::defaults(), 'same:password2'];
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Modpack;
 use App\Models\User;
 use App\Models\UserPermission;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -37,6 +38,12 @@ class UserController extends Controller
                 ->withErrors(['User ID not provided']);
         }
 
+        // Gate non-managers out before the lookup so the response can't be used
+        // to tell which user ids exist. Editing yourself needs no permission.
+        if ((int) $user_id !== Auth::id()) {
+            $this->authorize('viewAny', User::class);
+        }
+
         $user = User::find($user_id);
 
         if (empty($user)) {
@@ -46,7 +53,7 @@ class UserController extends Controller
 
         $this->authorize('update', $user);
 
-        $allModpacks = Modpack::all();
+        $allModpacks = $this->grantableModpackList();
 
         $userUpdatedBy = User::find($user->updated_by_user_id);
 
@@ -84,6 +91,12 @@ class UserController extends Controller
                 ->withErrors(['User ID not provided']);
         }
 
+        // Gate non-managers out before the lookup so the response can't be used
+        // to tell which user ids exist. Editing yourself needs no permission.
+        if ((int) $user_id !== Auth::id()) {
+            $this->authorize('viewAny', User::class);
+        }
+
         $user = User::find($user_id);
 
         if (empty($user)) {
@@ -118,33 +131,7 @@ class UserController extends Controller
         if (Auth::user()->permission->solder_full || Auth::user()->permission->solder_users) {
             $perm = $user->permission;
 
-            /* If user is original admin, always give full access. */
-            if ($user->id == 1) {
-                $perm->solder_full = true;
-            } elseif (Auth::user()->permission->solder_full) {
-                $perm->solder_full = \request()->boolean('solder-full');
-            }
-            $perm->solder_users = \request()->boolean('manage-users');
-            $perm->solder_keys = \request()->boolean('manage-keys');
-            $perm->solder_clients = \request()->boolean('manage-clients');
-
-            /* Mod Perms */
-            $perm->mods_create = \request()->boolean('mod-create');
-            $perm->mods_manage = \request()->boolean('mod-manage');
-            $perm->mods_delete = \request()->boolean('mod-delete');
-
-            /* Modpack Perms */
-            $perm->modpacks_create = \request()->boolean('modpack-create');
-            $perm->modpacks_manage = \request()->boolean('modpack-manage');
-            $perm->modpacks_delete = \request()->boolean('modpack-delete');
-            $modpack = Request::input('modpack');
-
-            if (! empty($modpack)) {
-                $modpack = array_filter(array_map('intval', (array) $modpack));
-                $perm->modpacks = Modpack::whereIn('id', $modpack)->pluck('id')->all() ?: null;
-            } else {
-                $perm->modpacks = null;
-            }
+            $this->applyGrantablePermissions($perm, Auth::user(), (int) $user->id === 1);
 
             $perm->save();
         }
@@ -164,7 +151,7 @@ class UserController extends Controller
     {
         $this->authorize('create', User::class);
 
-        $allModpacks = Modpack::all();
+        $allModpacks = $this->grantableModpackList();
 
         return view('user.create')
             ->with('allModpacks', $allModpacks);
@@ -188,56 +175,47 @@ class UserController extends Controller
         $creator = Auth::user()->id;
         $creatorIP = Request::ip();
 
-        $user = new User;
-        $user->email = Request::input('email');
-        $user->username = Request::input('username');
-        $user->password = Request::input('password');
-        $user->created_ip = $creatorIP;
-        $user->created_by_user_id = $creator;
-        $user->updated_by_ip = $creatorIP;
-        $user->updated_by_user_id = $creator;
-        $user->save();
+        // The user and its permission row are written together: a failure between
+        // the two would otherwise leave a user with no permissions at all, which
+        // no manager can then act on.
+        $user = DB::transaction(function () use ($creator, $creatorIP) {
+            $user = new User;
+            $user->email = Request::input('email');
+            $user->username = Request::input('username');
+            $user->password = Request::input('password');
+            $user->created_ip = $creatorIP;
+            $user->created_by_user_id = $creator;
+            $user->updated_by_ip = $creatorIP;
+            $user->updated_by_user_id = $creator;
+            $user->save();
 
-        $perm = new UserPermission;
-        $perm->user_id = $user->id;
+            $perm = new UserPermission;
+            $perm->user_id = $user->id;
 
-        $perm->solder_full = Auth::user()->permission->solder_full && \request()->boolean('solder-full');
-        $perm->solder_users = \request()->boolean('manage-users');
-        $perm->solder_keys = \request()->boolean('manage-keys');
-        $perm->solder_clients = \request()->boolean('manage-clients');
+            $this->applyGrantablePermissions($perm, Auth::user(), false);
 
-        /* Mod Perms */
-        $perm->mods_create = \request()->boolean('mod-create');
-        $perm->mods_manage = \request()->boolean('mod-manage');
-        $perm->mods_delete = \request()->boolean('mod-delete');
+            $perm->save();
 
-        /* Modpack Perms */
-        $perm->modpacks_create = \request()->boolean('modpack-create');
-        $perm->modpacks_manage = \request()->boolean('modpack-manage');
-        $perm->modpacks_delete = \request()->boolean('modpack-delete');
-        $modpack = Request::input('modpack');
-
-        if (! empty($modpack)) {
-            $modpack = array_filter(array_map('intval', (array) $modpack));
-            $perm->modpacks = Modpack::whereIn('id', $modpack)->pluck('id')->all() ?: null;
-        } else {
-            $perm->modpacks = null;
-        }
-
-        $perm->save();
+            return $user;
+        });
 
         return redirect('user/edit/'.$user->id)->with('success', 'User created!');
     }
 
     public function postResetTwoFactor($user_id): RedirectResponse
     {
-        $this->authorize('delete', User::class);
+        // Admin-only recovery action: gate non-managers out before the lookup
+        // (avoids leaking which user ids exist), then confirm this manager may
+        // act on the target. Deliberately not the self-passing `update` ability.
+        $this->authorize('viewAny', User::class);
 
         $user = User::find($user_id);
 
         if (empty($user)) {
             return redirect('user/list')->withErrors(['User not found']);
         }
+
+        $this->authorize('delete', $user);
 
         $user->forceFill([
             'two_factor_secret' => null,
@@ -250,7 +228,7 @@ class UserController extends Controller
 
     public function getDelete($user_id = null)
     {
-        $this->authorize('delete', User::class);
+        $this->authorize('viewAny', User::class);
 
         if (empty($user_id)) {
             return redirect('user/list')
@@ -261,6 +239,13 @@ class UserController extends Controller
         if (empty($user)) {
             return redirect('user/list')
                 ->withErrors(['User not found']);
+        }
+
+        $this->authorize('delete', $user);
+
+        if ((int) $user_id === Auth::id()) {
+            return redirect('user/list')
+                ->withErrors(['You cannot delete your own account.']);
         }
 
         if ($user->permission->solder_full) {
@@ -280,7 +265,7 @@ class UserController extends Controller
 
     public function postDelete($user_id = null): RedirectResponse
     {
-        $this->authorize('delete', User::class);
+        $this->authorize('viewAny', User::class);
 
         if (empty($user_id)) {
             return redirect('user/list')
@@ -291,6 +276,13 @@ class UserController extends Controller
         if (empty($user)) {
             return redirect('user/list')
                 ->withErrors(['User not found']);
+        }
+
+        $this->authorize('delete', $user);
+
+        if ((int) $user_id === Auth::id()) {
+            return redirect('user/list')
+                ->withErrors(['You cannot delete your own account.']);
         }
 
         if ($user->permission->solder_full) {
@@ -342,5 +334,61 @@ class UserController extends Controller
         $token->delete();
 
         return redirect('user/edit/'.$user->id)->with('success', 'API token revoked.');
+    }
+
+    /**
+     * Assign permissions to $perm from the request, clamped to what the acting
+     * user is allowed to grant. A non-superadmin may only grant (or revoke)
+     * permissions they hold themselves; permissions they lack are left at the
+     * target's existing value. Only a solder_full user may grant anything.
+     */
+    private function applyGrantablePermissions(UserPermission $perm, User $actor, bool $isOriginalAdmin): void
+    {
+        foreach (UserPermission::GRANTABLE_FIELDS as $column => $field) {
+            if ($actor->can('grant-permission', $column)) {
+                $perm->{$column} = \request()->boolean($field);
+            }
+        }
+
+        // The original admin (user 1) is always a superadmin.
+        if ($isOriginalAdmin) {
+            $perm->solder_full = true;
+        }
+
+        $perm->modpacks = $this->grantableModpacks($actor);
+    }
+
+    /**
+     * The per-modpack scope to assign, clamped to what the actor may grant: the
+     * requested ids intersected with the actor's own scope (the full requested
+     * set for a solder_full actor), validated against existing modpacks.
+     *
+     * @return list<int>|null
+     */
+    private function grantableModpacks(User $actor): ?array
+    {
+        $requested = array_filter(array_map('intval', (array) Request::input('modpack')));
+
+        if (! $actor->permission->solder_full) {
+            $actorPacks = array_map('intval', $actor->permission->modpacks);
+            $requested = array_intersect($requested, $actorPacks);
+        }
+
+        return Modpack::whereIn('id', $requested)->pluck('id')->all() ?: null;
+    }
+
+    /**
+     * The modpacks the acting user may assign in the create/edit forms: all
+     * modpacks for a solder_full user, otherwise only those in their own scope.
+     *
+     * @return Collection<int, Modpack>
+     */
+    private function grantableModpackList(): Collection
+    {
+        $actorPerm = Auth::user()->permission;
+
+        return $actorPerm->solder_full
+            ? Modpack::all()
+            : Modpack::whereIn('id', $actorPerm->modpacks)->get();
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -112,6 +112,10 @@ class UserController extends Controller
         ];
 
         if (Request::input('password1')) {
+            // Proof of identity for a session takeover, not proof of the target's
+            // password: `current_password:web` checks the *actor*, so a manager
+            // resetting someone else's password confirms their own.
+            $rules['current_password'] = ['required', 'current_password:web'];
             $rules['password1'] = [Password::defaults(), 'same:password2'];
         }
 

--- a/app/Listeners/UpdateUserLoginDetails.php
+++ b/app/Listeners/UpdateUserLoginDetails.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Libraries\UpdateUtils;
+use App\Models\User;
+use Illuminate\Auth\Events\Login;
+
+class UpdateUserLoginDetails
+{
+    /**
+     * Record the login and refresh the superadmin update banner.
+     *
+     * Bound to the Login event rather than Fortify::authenticateUsing(), which
+     * fires once per credential check: twice on a plain login, and before the
+     * second factor is supplied on a 2FA one. The guard fires this only once
+     * authentication has fully succeeded, 2FA challenge included.
+     */
+    public function handle(Login $event): void
+    {
+        if (! $event->user instanceof User) {
+            return;
+        }
+
+        $user = $event->user;
+
+        $user->last_ip = request()->ip();
+        $user->save();
+
+        // Best-effort banner data behind a 60 minute cache. It reaches out to
+        // the GitHub API, so it must not hold up the login response.
+        defer(function () use ($user) {
+            if ($user->permission->solder_full && UpdateUtils::getUpdateCheck()) {
+                cache()->put('update', true, now()->addMinutes(60));
+            }
+        });
+    }
+}

--- a/app/Models/UserPermission.php
+++ b/app/Models/UserPermission.php
@@ -47,6 +47,41 @@ use Illuminate\Support\Carbon;
  */
 class UserPermission extends Model
 {
+    /**
+     * The grantable boolean permission columns, mapped to the form field that
+     * sets them. Single source of truth for the grant clamp (`grant-permission`
+     * gate), the create/edit forms, and the user-management subset check —
+     * adding a permission means adding one entry here.
+     *
+     * Excludes the per-modpack `modpacks` scope, which is not a boolean flag.
+     *
+     * @var array<string, string>
+     */
+    public const GRANTABLE_FIELDS = [
+        'solder_full' => 'solder-full',
+        'solder_users' => 'manage-users',
+        'solder_keys' => 'manage-keys',
+        'solder_clients' => 'manage-clients',
+        'mods_create' => 'mod-create',
+        'mods_manage' => 'mod-manage',
+        'mods_delete' => 'mod-delete',
+        'modpacks_create' => 'modpack-create',
+        'modpacks_manage' => 'modpack-manage',
+        'modpacks_delete' => 'modpack-delete',
+    ];
+
+    /**
+     * The permission columns compared when deciding whether one user's
+     * permissions are a subset of another's. Excludes solder_full, which is
+     * handled separately by the Gate::before superadmin bypass.
+     *
+     * @return list<string>
+     */
+    public static function permissionFlags(): array
+    {
+        return array_values(array_diff(array_keys(self::GRANTABLE_FIELDS), ['solder_full']));
+    }
+
     protected $fillable = [
         'user_id',
         'solder_full',

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -3,6 +3,7 @@
 namespace App\Policies;
 
 use App\Models\User;
+use App\Models\UserPermission;
 
 class UserPolicy
 {
@@ -16,13 +17,54 @@ class UserPolicy
         return $user->permission->solder_users;
     }
 
+    /**
+     * A user may always edit their own profile; the controller clamps which
+     * permissions a non-superadmin can actually change. Otherwise the actor
+     * must be able to manage the target. solder_full is handled by the
+     * Gate::before in AppServiceProvider, so it never reaches here.
+     */
     public function update(User $user, User $target): bool
     {
-        return $user->permission->solder_users || $user->id === $target->id;
+        return $user->id === $target->id || $this->canManage($user, $target);
     }
 
-    public function delete(User $user): bool
+    public function delete(User $user, User $target): bool
     {
-        return $user->permission->solder_users;
+        return $this->canManage($user, $target);
+    }
+
+    /**
+     * Whether a non-superadmin manager may act on $target. They must hold
+     * solder_users, and $target's permissions must be a subset of their own —
+     * so a delegate can never edit, delete, or reset 2FA for a more-privileged
+     * account (and never for a solder_full superadmin). An equal peer is a
+     * subset of itself, so peer management is allowed.
+     */
+    private function canManage(User $actor, User $target): bool
+    {
+        $actorPerm = $actor->permission;
+        $targetPerm = $target->permission;
+
+        if (! $actorPerm || ! $targetPerm || ! $actorPerm->solder_users) {
+            return false;
+        }
+
+        if ($targetPerm->solder_full) {
+            return false;
+        }
+
+        foreach (UserPermission::permissionFlags() as $flag) {
+            if ($targetPerm->{$flag} && ! $actorPerm->{$flag}) {
+                return false;
+            }
+        }
+
+        foreach ($targetPerm->modpacks as $modpackId) {
+            if (! $actorPerm->canAccessModpack((int) $modpackId)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,7 +14,9 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Password;
+use Laravel\Fortify\Fortify;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -82,9 +84,23 @@ class AppServiceProvider extends ServiceProvider
 
         $this->bootRoute();
 
-        RateLimiter::for('login', fn (Request $request) => Limit::perMinute(5)->by($request->input('email').'|'.$request->ip()));
+        RateLimiter::for('login', fn (Request $request) => Limit::perMinute(5)->by($this->loginThrottleKey($request)));
         RateLimiter::for('two-factor', fn (Request $request) => Limit::perMinute(5)->by($request->session()->get('login.id')));
         RateLimiter::for('key-verify', fn (Request $request) => Limit::perMinute(10)->by($request->ip()));
+    }
+
+    /**
+     * Build the throttle key for a login attempt.
+     *
+     * Canonicalized the same way Fortify's own LoginRateLimiter does, because
+     * the `throttle:login` route middleware runs before Fortify's
+     * CanonicalizeUsername action lowercases the username. Without this, casing
+     * or homoglyph variants of one address each get their own bucket while all
+     * authenticating as the same account.
+     */
+    private function loginThrottleKey(Request $request): string
+    {
+        return Str::transliterate(Str::lower((string) $request->input(Fortify::username())).'|'.$request->ip());
     }
 
     public function bootRoute(): void

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Models\Modpack;
 use App\Models\User;
+use App\Models\UserPermission;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -49,6 +50,17 @@ class AppServiceProvider extends ServiceProvider
         Model::preventSilentlyDiscardingAttributes(! app()->isProduction());
 
         Gate::before(fn (User $user) => $user->permission->solder_full ?: null);
+
+        // A non-superadmin may only delegate permissions they hold themselves;
+        // solder_full is handled by the Gate::before above. The permission is
+        // whitelisted so an unexpected column name can never authorize a grant.
+        Gate::define('grant-permission', function (User $user, string $permission) {
+            if (! array_key_exists($permission, UserPermission::GRANTABLE_FIELDS)) {
+                return false;
+            }
+
+            return (bool) $user->permission->{$permission};
+        });
 
         View::composer('layouts.master', function ($view) {
             $modpacks = Cache::remember('allmodpacks', now()->addMinute(), function () {

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -4,10 +4,6 @@ namespace App\Providers;
 
 use App\Actions\ResetUserPassword;
 use App\Http\Responses\LogoutResponse;
-use App\Libraries\UpdateUtils;
-use App\Models\User;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
 use Laravel\Fortify\Contracts\ResetsUserPasswords;
@@ -29,22 +25,5 @@ class FortifyServiceProvider extends ServiceProvider
 
         Fortify::requestPasswordResetLinkView(fn () => view('auth.forgot-password'));
         Fortify::resetPasswordView(fn ($request) => view('auth.reset-password', ['request' => $request]));
-
-        Fortify::authenticateUsing(function (Request $request) {
-            $user = User::where('email', $request->email)->first();
-
-            if ($user && Hash::check($request->password, $user->password)) {
-                $user->last_ip = $request->ip();
-                $user->save();
-
-                if ($user->permission->solder_full && UpdateUtils::getUpdateCheck()) {
-                    cache()->put('update', true, now()->addMinutes(60));
-                }
-
-                return $user;
-            }
-
-            return null;
-        });
     }
 }

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,8 +1,10 @@
-# Standalone development stack. Run it on its own; do NOT merge with compose.yml:
+# Development stack owned by the technicsolder-dev Compose project. Run it on its own; do NOT merge with compose.yml:
 #   docker compose -f compose.dev.yml up -d
 # Combining the two files (-f compose.yml -f compose.dev.yml) pulls in the
 # production MariaDB service and its env-injection block, which breaks the
 # postgres dev database and test isolation.
+name: technicsolder-dev
+
 services:
   nginx:
     image: nginx

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,3 +1,8 @@
+# Standalone development stack. Run it on its own; do NOT merge with compose.yml:
+#   docker compose -f compose.dev.yml up -d
+# Combining the two files (-f compose.yml -f compose.dev.yml) pulls in the
+# production MariaDB service and its env-injection block, which breaks the
+# postgres dev database and test isolation.
 services:
   nginx:
     image: nginx

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -40,6 +40,7 @@
                             <input type="password"
                                    name="password"
                                    id="password"
+                                   autocomplete="new-password"
                                    class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors">
                         </div>
 

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -58,26 +58,34 @@
                         <div class="mb-5">
                             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Solderwide</label>
                             <div class="space-y-2">
+                                @can('grant-permission', 'solder_full')
                                 <label for="solder-full" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                     <input type="checkbox" name="solder-full" id="solder-full"
                                            class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                     Full Solder Access (Blanket permission)
                                 </label>
+                                @endcan
+                                @can('grant-permission', 'solder_users')
                                 <label for="manage-users" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                     <input type="checkbox" name="manage-users" id="manage-users"
                                            class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                     Manage Users
                                 </label>
+                                @endcan
+                                @can('grant-permission', 'solder_keys')
                                 <label for="manage-keys" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                     <input type="checkbox" name="manage-keys" id="manage-keys"
                                            class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                     Manage Platform Keys
                                 </label>
+                                @endcan
+                                @can('grant-permission', 'solder_clients')
                                 <label for="manage-clients" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                     <input type="checkbox" name="manage-clients" id="manage-clients"
                                            class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                     Manage Clients
                                 </label>
+                                @endcan
                             </div>
                         </div>
 
@@ -85,21 +93,27 @@
                         <div class="mb-5">
                             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Mod Library</label>
                             <div class="space-y-2">
+                                @can('grant-permission', 'mods_create')
                                 <label for="mod-create" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                     <input type="checkbox" name="mod-create" id="mod-create"
                                            class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                     Create Mods
                                 </label>
+                                @endcan
+                                @can('grant-permission', 'mods_manage')
                                 <label for="mod-manage" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                     <input type="checkbox" name="mod-manage" id="mod-manage"
                                            class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                     Manage Mods
                                 </label>
+                                @endcan
+                                @can('grant-permission', 'mods_delete')
                                 <label for="mod-delete" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                     <input type="checkbox" name="mod-delete" id="mod-delete"
                                            class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                     Delete Mods
                                 </label>
+                                @endcan
                             </div>
                         </div>
 
@@ -112,21 +126,27 @@
                                 if the specific modpack is selected.
                             </p>
                             <div class="space-y-2">
+                                @can('grant-permission', 'modpacks_create')
                                 <label for="modpack-create" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                     <input type="checkbox" name="modpack-create" id="modpack-create"
                                            class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                     Create Modpacks
                                 </label>
+                                @endcan
+                                @can('grant-permission', 'modpacks_manage')
                                 <label for="modpack-manage" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                     <input type="checkbox" name="modpack-manage" id="modpack-manage"
                                            class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                     Manage Modpacks
                                 </label>
+                                @endcan
+                                @can('grant-permission', 'modpacks_delete')
                                 <label for="modpack-delete" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                     <input type="checkbox" name="modpack-delete" id="modpack-delete"
                                            class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                     Delete Modpacks
                                 </label>
+                                @endcan
                             </div>
                         </div>
 
@@ -135,7 +155,7 @@
                             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Specific Modpacks</label>
                             <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">Select which modpacks this user can access. Changes take effect when you save.</p>
                             @if ($allModpacks->isEmpty())
-                                <p class="text-sm text-gray-500 dark:text-gray-400">No modpacks exist.</p>
+                                <p class="text-sm text-gray-500 dark:text-gray-400">No modpacks available to assign.</p>
                             @else
                                 <div x-data="{
                                     options: @js($allModpacks->sortBy('name', SORT_NATURAL | SORT_FLAG_CASE)->map(fn($m) => ['id' => $m->id, 'name' => $m->name])->values()),

--- a/resources/views/user/edit.blade.php
+++ b/resources/views/user/edit.blade.php
@@ -73,6 +73,22 @@
                                    class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors">
                         </div>
 
+                        <div class="mb-4">
+                            <label for="current_password" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Your Current Password</label>
+                            <input type="password"
+                                   name="current_password"
+                                   id="current_password"
+                                   autocomplete="current-password"
+                                   class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors">
+                            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                @if (Auth::id() === $user->id)
+                                    Required only when setting a new password above.
+                                @else
+                                    Required only when setting a new password above &mdash; enter your own password, not {{ $user->username }}'s.
+                                @endif
+                            </p>
+                        </div>
+
                     </div>
 
                     {{-- Right column: Permissions --}}

--- a/resources/views/user/edit.blade.php
+++ b/resources/views/user/edit.blade.php
@@ -60,6 +60,7 @@
                             <input type="password"
                                    name="password1"
                                    id="password1"
+                                   autocomplete="new-password"
                                    class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors">
                         </div>
 
@@ -68,6 +69,7 @@
                             <input type="password"
                                    name="password2"
                                    id="password2"
+                                   autocomplete="new-password"
                                    class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors">
                         </div>
 
@@ -445,6 +447,7 @@
                             <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">Please confirm your password to continue.</p>
                             <div class="mb-4">
                                 <input type="password" x-model="password" x-ref="passwordInput" @keydown.enter="submit()"
+                                       autocomplete="current-password"
                                        placeholder="Password"
                                        class="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-colors">
                                 <p x-show="error" x-text="error" class="mt-1 text-sm text-red-600 dark:text-red-400"></p>

--- a/resources/views/user/edit.blade.php
+++ b/resources/views/user/edit.blade.php
@@ -87,30 +87,38 @@
                             <div class="mb-5">
                                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Solderwide</label>
                                 <div class="space-y-2">
+                                    @can('grant-permission', 'solder_full')
                                     <label for="solder-full" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                         <input type="checkbox" name="solder-full" id="solder-full"
                                                @checked($user->permission->solder_full)
                                                class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                         Full Solder Access (Blanket permission)
                                     </label>
+                                    @endcan
+                                    @can('grant-permission', 'solder_users')
                                     <label for="manage-users" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                         <input type="checkbox" name="manage-users" id="manage-users"
                                                @checked($user->permission->solder_users)
                                                class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                         Manage Users
                                     </label>
+                                    @endcan
+                                    @can('grant-permission', 'solder_keys')
                                     <label for="manage-keys" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                         <input type="checkbox" name="manage-keys" id="manage-keys"
                                                @checked($user->permission->solder_keys)
                                                class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                         Manage Platform Keys
                                     </label>
+                                    @endcan
+                                    @can('grant-permission', 'solder_clients')
                                     <label for="manage-clients" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                         <input type="checkbox" name="manage-clients" id="manage-clients"
                                                @checked($user->permission->solder_clients)
                                                class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                         Manage Clients
                                     </label>
+                                    @endcan
                                 </div>
                             </div>
 
@@ -118,24 +126,30 @@
                             <div class="mb-5">
                                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Mod Library</label>
                                 <div class="space-y-2">
+                                    @can('grant-permission', 'mods_create')
                                     <label for="mod-create" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                         <input type="checkbox" name="mod-create" id="mod-create"
                                                @checked($user->permission->mods_create)
                                                class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                         Create Mods
                                     </label>
+                                    @endcan
+                                    @can('grant-permission', 'mods_manage')
                                     <label for="mod-manage" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                         <input type="checkbox" name="mod-manage" id="mod-manage"
                                                @checked($user->permission->mods_manage)
                                                class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                         Manage Mods
                                     </label>
+                                    @endcan
+                                    @can('grant-permission', 'mods_delete')
                                     <label for="mod-delete" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                         <input type="checkbox" name="mod-delete" id="mod-delete"
                                                @checked($user->permission->mods_delete)
                                                class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                         Delete Mods
                                     </label>
+                                    @endcan
                                 </div>
                             </div>
 
@@ -148,24 +162,30 @@
                                     even if the specific modpack is selected.
                                 </p>
                                 <div class="space-y-2">
+                                    @can('grant-permission', 'modpacks_create')
                                     <label for="modpack-create" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                         <input type="checkbox" name="modpack-create" id="modpack-create"
                                                @checked($user->permission->modpacks_create)
                                                class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                         Create Modpacks
                                     </label>
+                                    @endcan
+                                    @can('grant-permission', 'modpacks_manage')
                                     <label for="modpack-manage" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                         <input type="checkbox" name="modpack-manage" id="modpack-manage"
                                                @checked($user->permission->modpacks_manage)
                                                class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                         Manage Modpacks
                                     </label>
+                                    @endcan
+                                    @can('grant-permission', 'modpacks_delete')
                                     <label for="modpack-delete" class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
                                         <input type="checkbox" name="modpack-delete" id="modpack-delete"
                                                @checked($user->permission->modpacks_delete)
                                                class="size-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500">
                                         Delete Modpacks
                                     </label>
+                                    @endcan
                                 </div>
                             </div>
 
@@ -174,7 +194,7 @@
                                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Specific Modpacks</label>
                                 <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">Select which modpacks this user can access. Changes take effect when you save.</p>
                                 @if ($allModpacks->isEmpty())
-                                    <p class="text-sm text-gray-500 dark:text-gray-400">No modpacks exist.</p>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">No modpacks available to assign.</p>
                                 @else
                                     <div x-data="{
                                         options: @js($allModpacks->sortBy('name', SORT_NATURAL | SORT_FLAG_CASE)->map(fn($m) => ['id' => $m->id, 'name' => $m->name])->values()),

--- a/tests/Unit/AuthTest.php
+++ b/tests/Unit/AuthTest.php
@@ -132,6 +132,50 @@ final class AuthTest extends TestCase
         $response->assertStatus(429);
     }
 
+    public function test_rate_limiting_is_not_bypassed_by_email_casing(): void
+    {
+        // Fortify lowercases the username when authenticating, so every casing
+        // variant below targets the same account and must share one bucket.
+        $variants = [
+            'admin@example.com',
+            'Admin@example.com',
+            'ADMIN@EXAMPLE.COM',
+            'AdMiN@ExAmPlE.cOm',
+            'aDMIN@example.COM',
+        ];
+
+        foreach ($variants as $variant) {
+            $this->post('/login', ['email' => $variant, 'password' => 'wrong']);
+        }
+
+        $response = $this->post('/login', [
+            'email' => 'admin@example.com',
+            'password' => 'wrong',
+        ]);
+
+        $response->assertStatus(429);
+    }
+
+    public function test_rate_limiting_is_not_bypassed_by_transliteration(): void
+    {
+        // Accented homoglyphs fold to plain ASCII in the throttle key, so they
+        // cannot be used to mint a fresh bucket for the same target address.
+        for ($i = 0; $i < 3; $i++) {
+            $this->post('/login', ['email' => 'admin@example.com', 'password' => 'wrong']);
+        }
+
+        foreach (['ádmin@example.com', 'admın@example.com'] as $homoglyph) {
+            $this->post('/login', ['email' => $homoglyph, 'password' => 'wrong']);
+        }
+
+        $response = $this->post('/login', [
+            'email' => 'admin@example.com',
+            'password' => 'wrong',
+        ]);
+
+        $response->assertStatus(429);
+    }
+
     public function test_successful_login_after_failed_attempts(): void
     {
         for ($i = 0; $i < 3; $i++) {

--- a/tests/Unit/AuthTest.php
+++ b/tests/Unit/AuthTest.php
@@ -4,6 +4,10 @@ namespace Tests\Unit;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use PragmaRX\Google2FA\Google2FA;
 use Tests\TestCase;
 
 final class AuthTest extends TestCase
@@ -71,6 +75,100 @@ final class AuthTest extends TestCase
 
         $user = User::find(1);
         $this->assertNotNull($user->last_ip);
+    }
+
+    private function enableAndConfirm2FA(User $user): void
+    {
+        $this->actingAs($user);
+        session()->put('auth.password_confirmed_at', time());
+
+        $this->post('/user/two-factor-authentication');
+
+        $user->refresh();
+
+        $google2fa = new Google2FA;
+        $this->post('/user/confirmed-two-factor-authentication', [
+            'code' => $google2fa->getCurrentOtp(decrypt($user->two_factor_secret)),
+        ]);
+
+        $user->refresh();
+        auth()->logout();
+    }
+
+    public function test_login_side_effects_do_not_run_before_two_factor_challenge(): void
+    {
+        $user = User::find(1);
+        $this->enableAndConfirm2FA($user);
+
+        $user->last_ip = '10.0.0.1';
+        $user->save();
+
+        // Correct password, but the second factor has not been supplied yet.
+        $response = $this->post('/login', [
+            'email' => 'admin@example.com',
+            'password' => 'admin',
+        ]);
+
+        $response->assertRedirect('/two-factor-challenge');
+        $this->assertGuest();
+
+        $user->refresh();
+        $this->assertSame('10.0.0.1', $user->last_ip, 'last_ip must not be recorded until the 2FA challenge passes.');
+    }
+
+    public function test_last_ip_is_updated_after_two_factor_challenge_completes(): void
+    {
+        $user = User::find(1);
+        $this->enableAndConfirm2FA($user);
+
+        $user->last_ip = '10.0.0.1';
+        $user->save();
+
+        $secret = decrypt($user->two_factor_secret);
+
+        // Confirming 2FA above consumed the current OTP window; clear the
+        // replay cache so the same code is accepted for the challenge.
+        Cache::flush();
+
+        $this->post('/login', [
+            'email' => 'admin@example.com',
+            'password' => 'admin',
+        ]);
+
+        $google2fa = new Google2FA;
+        $response = $this->post('/two-factor-challenge', [
+            'code' => $google2fa->getCurrentOtp($secret),
+        ]);
+
+        $response->assertRedirect('/dashboard');
+        $this->assertAuthenticated();
+
+        $user->refresh();
+        $this->assertSame('127.0.0.1', $user->last_ip);
+    }
+
+    public function test_password_is_rehashed_on_login(): void
+    {
+        $user = User::find(1);
+
+        // Plant the same password at a work factor that differs from the
+        // configured one (phpunit.xml pins BCRYPT_ROUNDS to 4) so the guard has
+        // a reason to rehash it. Written straight to the column because the
+        // `hashed` cast refuses to store a hash the current config wouldn't
+        // produce, which is precisely the situation being simulated.
+        $staleHash = password_hash('admin', PASSWORD_BCRYPT, ['cost' => 6]);
+        DB::table('users')->where('id', $user->id)->update(['password' => $staleHash]);
+
+        $this->post('/login', [
+            'email' => 'admin@example.com',
+            'password' => 'admin',
+        ]);
+
+        $this->assertAuthenticated();
+
+        $user->refresh();
+        $this->assertNotSame($staleHash, $user->password, 'The outdated hash must be upgraded on login.');
+        $this->assertTrue(Hash::check('admin', $user->password));
     }
 
     public function test_login_with_remember_sets_token(): void

--- a/tests/Unit/AuthorizationTest.php
+++ b/tests/Unit/AuthorizationTest.php
@@ -23,9 +23,10 @@ final class AuthorizationTest extends TestCase
 
     private function createUserWithPermissions(array $perms = []): User
     {
+        $unique = uniqid();
         $user = new User;
-        $user->username = 'testuser';
-        $user->email = 'test@example.com';
+        $user->username = 'testuser-'.$unique;
+        $user->email = 'test-'.$unique.'@example.com';
         $user->password = 'password';
         $user->created_ip = '127.0.0.1';
         $user->created_by_user_id = 1;
@@ -199,6 +200,24 @@ final class AuthorizationTest extends TestCase
     {
         $user = $this->createUserWithPermissions();
         $this->actingAs($user)->get('/user/edit/1')
+            ->assertRedirect('/dashboard');
+    }
+
+    public function test_edit_denial_does_not_reveal_whether_user_exists(): void
+    {
+        $user = $this->createUserWithPermissions();
+        $target = $this->createUserWithPermissions();
+
+        // A non-manager must get the same denial for a real id as for an absent
+        // one; a "User not found" error would enumerate the user table.
+        $this->actingAs($user)->get('/user/edit/'.$target->id)
+            ->assertRedirect('/dashboard');
+        $this->actingAs($user)->get('/user/edit/999999')
+            ->assertRedirect('/dashboard');
+
+        $this->actingAs($user)->post('/user/edit/'.$target->id)
+            ->assertRedirect('/dashboard');
+        $this->actingAs($user)->post('/user/edit/999999')
             ->assertRedirect('/dashboard');
     }
 
@@ -411,5 +430,209 @@ final class AuthorizationTest extends TestCase
             ->assertJson(['status' => 'success']);
 
         $this->assertModelMissing($version);
+    }
+
+    // --- User permission delegation (clamp) ---
+    //
+    // A solder_users delegate may only grant permissions it holds itself; only
+    // solder_full may grant arbitrarily. A delegate also cannot act on a
+    // more-privileged account (UserPolicy subset check).
+
+    public function test_manager_cannot_grant_permissions_it_lacks_on_create(): void
+    {
+        $actor = $this->createUserWithPermissions(['solder_users' => true, 'mods_manage' => true]);
+
+        $this->actingAs($actor)->post('/user/create', [
+            'username' => 'delegated',
+            'email' => 'delegated@example.com',
+            'password' => 'B3sTp@ss',
+            'manage-users' => 'on', // actor holds solder_users -> granted
+            'mod-manage' => 'on',   // actor holds mods_manage -> granted
+            'mod-delete' => 'on',   // actor lacks mods_delete -> clamped
+            'manage-keys' => 'on',  // actor lacks solder_keys -> clamped
+            'solder-full' => 'on',  // never grantable by a non-superadmin
+        ]);
+
+        $perm = User::where('email', 'delegated@example.com')->firstOrFail()->permission;
+        $this->assertTrue((bool) $perm->solder_users);
+        $this->assertTrue((bool) $perm->mods_manage);
+        $this->assertFalse((bool) $perm->mods_delete);
+        $this->assertFalse((bool) $perm->solder_keys);
+        $this->assertFalse((bool) $perm->solder_full);
+    }
+
+    public function test_manager_cannot_grant_permissions_it_lacks_on_edit(): void
+    {
+        $actor = $this->createUserWithPermissions(['solder_users' => true, 'mods_manage' => true]);
+        $target = $this->createUserWithPermissions(['mods_manage' => true]);
+
+        $this->actingAs($actor)->post('/user/edit/'.$target->id, [
+            'username' => $target->username,
+            'email' => $target->email,
+            'mod-manage' => 'on',
+            'mod-delete' => 'on',  // actor lacks -> must not be granted
+            'manage-keys' => 'on', // actor lacks -> must not be granted
+        ]);
+
+        $perm = $target->fresh()->permission;
+        $this->assertTrue((bool) $perm->mods_manage);
+        $this->assertFalse((bool) $perm->mods_delete);
+        $this->assertFalse((bool) $perm->solder_keys);
+    }
+
+    public function test_manager_cannot_escalate_own_permissions_on_self_edit(): void
+    {
+        $actor = $this->createUserWithPermissions(['solder_users' => true, 'mods_manage' => true]);
+
+        $this->actingAs($actor)->post('/user/edit/'.$actor->id, [
+            'username' => $actor->username,
+            'email' => $actor->email,
+            'manage-users' => 'on',
+            'mod-manage' => 'on',
+            'mod-delete' => 'on',  // self-grant must be clamped
+            'solder-full' => 'on', // self-promotion must be clamped
+        ]);
+
+        $perm = $actor->fresh()->permission;
+        $this->assertTrue((bool) $perm->solder_users);
+        $this->assertTrue((bool) $perm->mods_manage);
+        $this->assertFalse((bool) $perm->mods_delete);
+        $this->assertFalse((bool) $perm->solder_full);
+    }
+
+    public function test_manager_cannot_grant_modpacks_outside_own_scope(): void
+    {
+        $packA = Modpack::create(['name' => 'Clamp Pack A', 'slug' => 'clamp-pack-a']);
+        $packB = Modpack::create(['name' => 'Clamp Pack B', 'slug' => 'clamp-pack-b']);
+
+        $actor = $this->createUserWithPermissions(['solder_users' => true, 'modpacks_manage' => true]);
+        $actor->permission->modpacks = [$packA->id];
+        $actor->permission->save();
+        $actor->load('permission');
+
+        $this->actingAs($actor)->post('/user/create', [
+            'username' => 'scoped',
+            'email' => 'scoped@example.com',
+            'password' => 'B3sTp@ss',
+            'modpack-manage' => 'on',
+            'modpack' => [$packA->id, $packB->id],
+        ]);
+
+        $packs = array_map('intval', User::where('email', 'scoped@example.com')->firstOrFail()->permission->modpacks);
+        $this->assertContains((int) $packA->id, $packs);
+        $this->assertNotContains((int) $packB->id, $packs);
+    }
+
+    public function test_manager_cannot_edit_more_privileged_user(): void
+    {
+        $actor = $this->createUserWithPermissions(['solder_users' => true]);
+
+        // User 1 is the seeded solder_full superadmin.
+        $this->actingAs($actor)->get('/user/edit/1')->assertRedirect('/dashboard');
+        $this->actingAs($actor)->post('/user/edit/1', [
+            'username' => 'admin',
+            'email' => 'admin@example.com',
+        ])->assertRedirect('/dashboard');
+    }
+
+    public function test_manager_cannot_edit_user_with_extra_permissions(): void
+    {
+        $actor = $this->createUserWithPermissions(['solder_users' => true]);
+        $target = $this->createUserWithPermissions(['solder_users' => true, 'mods_delete' => true]);
+
+        $this->actingAs($actor)->post('/user/edit/'.$target->id, [
+            'username' => $target->username,
+            'email' => $target->email,
+        ])->assertRedirect('/dashboard');
+    }
+
+    public function test_solder_full_can_grant_any_permission(): void
+    {
+        $admin = User::find(1); // solder_full
+
+        $this->actingAs($admin)->post('/user/create', [
+            'username' => 'fullgrant',
+            'email' => 'fullgrant@example.com',
+            'password' => 'B3sTp@ss',
+            'mod-delete' => 'on',
+            'modpack-delete' => 'on',
+            'manage-keys' => 'on',
+        ]);
+
+        $perm = User::where('email', 'fullgrant@example.com')->firstOrFail()->permission;
+        $this->assertTrue((bool) $perm->mods_delete);
+        $this->assertTrue((bool) $perm->modpacks_delete);
+        $this->assertTrue((bool) $perm->solder_keys);
+    }
+
+    public function test_manager_cannot_reset_2fa_of_more_privileged_user(): void
+    {
+        $actor = $this->createUserWithPermissions(['solder_users' => true]);
+
+        $this->actingAs($actor)->post('/user/1/reset-2fa')->assertRedirect('/dashboard');
+    }
+
+    public function test_manager_can_reset_2fa_of_managed_user(): void
+    {
+        $actor = $this->createUserWithPermissions(['solder_users' => true]);
+        $target = $this->createUserWithPermissions();
+        $target->forceFill([
+            'two_factor_secret' => 'enrolled-secret',
+            'two_factor_confirmed_at' => now(),
+        ])->save();
+
+        $this->actingAs($actor)->post('/user/'.$target->id.'/reset-2fa')
+            ->assertRedirect('/user/edit/'.$target->id);
+
+        $target->refresh();
+        $this->assertNull($target->two_factor_secret);
+        $this->assertNull($target->two_factor_confirmed_at);
+    }
+
+    public function test_regular_user_cannot_reset_own_2fa(): void
+    {
+        $user = $this->createUserWithPermissions();
+
+        $this->actingAs($user)->post('/user/'.$user->id.'/reset-2fa')
+            ->assertRedirect('/dashboard');
+    }
+
+    public function test_regular_user_cannot_delete_users(): void
+    {
+        $user = $this->createUserWithPermissions();
+        $target = $this->createUserWithPermissions();
+
+        $this->actingAs($user)->post('/user/delete/'.$target->id)
+            ->assertRedirect('/dashboard');
+        $this->assertModelExists($target);
+    }
+
+    public function test_manager_cannot_delete_more_privileged_user(): void
+    {
+        $actor = $this->createUserWithPermissions(['solder_users' => true]);
+
+        // User 1 is the seeded solder_full superadmin.
+        $this->actingAs($actor)->post('/user/delete/1')->assertRedirect('/dashboard');
+        $this->assertDatabaseHas('users', ['id' => 1]);
+    }
+
+    public function test_manager_cannot_delete_user_with_extra_permissions(): void
+    {
+        $actor = $this->createUserWithPermissions(['solder_users' => true]);
+        $target = $this->createUserWithPermissions(['solder_users' => true, 'mods_delete' => true]);
+
+        $this->actingAs($actor)->post('/user/delete/'.$target->id)
+            ->assertRedirect('/dashboard');
+        $this->assertModelExists($target);
+    }
+
+    public function test_manager_can_delete_managed_user(): void
+    {
+        $actor = $this->createUserWithPermissions(['solder_users' => true]);
+        $target = $this->createUserWithPermissions();
+
+        $this->actingAs($actor)->post('/user/delete/'.$target->id)
+            ->assertRedirect('/user/list');
+        $this->assertModelMissing($target);
     }
 }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use App\Models\User;
 use App\Models\UserPermission;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
 
 final class UserTest extends TestCase
@@ -118,9 +119,9 @@ final class UserTest extends TestCase
             'Both edit form password fields must hint new-password so password managers offer to generate one.'
         );
         $this->assertSame(
-            1,
+            2,
             substr_count($content, 'autocomplete="current-password"'),
-            'The confirm password modal must hint current-password so password managers offer the existing one.'
+            'The confirm password modal and the current password field must both hint current-password so password managers offer the existing one.'
         );
     }
 
@@ -182,6 +183,122 @@ final class UserTest extends TestCase
         $response = $this->post('/user/edit/'.$user->id, $data);
         $response->assertRedirect('/user/edit/'.$user->id);
         $response->assertSessionHas('success');
+    }
+
+    public function test_password_change_requires_current_password(): void
+    {
+        $user = User::firstOrFail();
+
+        $response = $this->post('/user/edit/'.$user->id, [
+            'email' => $user->email,
+            'username' => $user->username,
+            'password1' => 'N3wP@ssw0rd!',
+            'password2' => 'N3wP@ssw0rd!',
+        ]);
+
+        $response->assertRedirect('/user/edit/'.$user->id);
+        $response->assertSessionHasErrors('current_password');
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('admin', $user->password), 'The password must be unchanged.');
+    }
+
+    public function test_password_change_rejects_wrong_current_password(): void
+    {
+        $user = User::firstOrFail();
+
+        $response = $this->post('/user/edit/'.$user->id, [
+            'email' => $user->email,
+            'username' => $user->username,
+            'current_password' => 'not-my-password',
+            'password1' => 'N3wP@ssw0rd!',
+            'password2' => 'N3wP@ssw0rd!',
+        ]);
+
+        $response->assertRedirect('/user/edit/'.$user->id);
+        $response->assertSessionHasErrors('current_password');
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('admin', $user->password), 'The password must be unchanged.');
+    }
+
+    public function test_password_change_succeeds_with_correct_current_password(): void
+    {
+        $user = User::firstOrFail();
+
+        $response = $this->post('/user/edit/'.$user->id, [
+            'email' => $user->email,
+            'username' => $user->username,
+            'current_password' => 'admin',
+            'password1' => 'N3wP@ssw0rd!',
+            'password2' => 'N3wP@ssw0rd!',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $response->assertRedirect('/user/edit/'.$user->id);
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('N3wP@ssw0rd!', $user->password));
+    }
+
+    public function test_admin_changing_another_users_password_supplies_own_current_password(): void
+    {
+        $target = User::unguarded(fn () => User::create([
+            'email' => 'target@example.com',
+            'username' => 'target',
+            'password' => 'targetpassword',
+            'created_ip' => '127.0.0.1',
+            'last_ip' => '127.0.0.1',
+            'created_by_user_id' => 1,
+        ]));
+
+        $perm = new UserPermission;
+        $perm->user_id = $target->id;
+        $perm->save();
+
+        // `current_password` is the acting admin's own password, never the
+        // target's — an admin cannot be expected to know the latter.
+        $response = $this->post('/user/edit/'.$target->id, [
+            'email' => $target->email,
+            'username' => $target->username,
+            'current_password' => 'admin',
+            'password1' => 'N3wP@ssw0rd!',
+            'password2' => 'N3wP@ssw0rd!',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+
+        $target->refresh();
+        $this->assertTrue(Hash::check('N3wP@ssw0rd!', $target->password));
+    }
+
+    public function test_admin_changing_another_users_password_rejects_targets_password(): void
+    {
+        $target = User::unguarded(fn () => User::create([
+            'email' => 'target2@example.com',
+            'username' => 'target2',
+            'password' => 'targetpassword',
+            'created_ip' => '127.0.0.1',
+            'last_ip' => '127.0.0.1',
+            'created_by_user_id' => 1,
+        ]));
+
+        $perm = new UserPermission;
+        $perm->user_id = $target->id;
+        $perm->save();
+
+        $response = $this->post('/user/edit/'.$target->id, [
+            'email' => $target->email,
+            'username' => $target->username,
+            'current_password' => 'targetpassword',
+            'password1' => 'N3wP@ssw0rd!',
+            'password2' => 'N3wP@ssw0rd!',
+        ]);
+
+        $response->assertSessionHasErrors('current_password');
+
+        $target->refresh();
+        $this->assertTrue(Hash::check('targetpassword', $target->password), 'The password must be unchanged.');
     }
 
     public function test_user_delete_get(): void

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -222,6 +222,25 @@ final class UserTest extends TestCase
         $this->assertTrue(Hash::check('admin', $user->password), 'The password must be unchanged.');
     }
 
+    public function test_password_change_rejects_array_current_password(): void
+    {
+        $user = User::firstOrFail();
+
+        $response = $this->post('/user/edit/'.$user->id, [
+            'email' => $user->email,
+            'username' => $user->username,
+            'current_password' => ['x'],
+            'password1' => 'N3wP@ssw0rd!',
+            'password2' => 'N3wP@ssw0rd!',
+        ]);
+
+        $response->assertRedirect('/user/edit/'.$user->id);
+        $response->assertSessionHasErrors('current_password');
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('admin', $user->password), 'The password must be unchanged.');
+    }
+
     public function test_password_change_succeeds_with_correct_current_password(): void
     {
         $user = User::firstOrFail();

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -203,7 +203,7 @@ final class UserTest extends TestCase
         $response->assertSessionHas('success');
     }
 
-    public function test_user_cannot_delete_last_admin_post(): void
+    public function test_non_superadmin_cannot_delete_superadmin(): void
     {
         // Create second user
         $user = User::unguarded(fn () => User::create([
@@ -224,14 +224,51 @@ final class UserTest extends TestCase
         // Auth as the new user
         $this->be($user);
 
+        // A non-superadmin may not act on a solder_full account at all, so the
+        // delete is denied outright rather than reaching the last-admin guard
+        // (which is exercised by test_user_cannot_delete_self for a superadmin).
         $response = $this->post('/user/delete/1');
-        $response->assertRedirect('/user/list');
-        $response->assertSessionHasErrors();
+        $response->assertRedirect('/dashboard');
+        $this->assertDatabaseHas('users', ['id' => 1]);
     }
 
     public function test_user_cannot_delete_self(): void
     {
         $response = $this->post('/user/delete/'.auth()->user()->id);
+        $response->assertRedirect('/user/list');
+        $response->assertSessionHasErrors();
+        $this->assertDatabaseHas('users', ['id' => auth()->user()->id]);
+    }
+
+    public function test_non_superadmin_cannot_delete_self(): void
+    {
+        $user = User::unguarded(fn () => User::create([
+            'email' => 'selfdelete@example.com',
+            'username' => 'selfdelete',
+            'password' => 'password',
+            'created_ip' => '127.0.0.1',
+            'last_ip' => '127.0.0.1',
+            'created_by_user_id' => 1,
+        ]));
+
+        // Enough permission to reach the delete handler, but self-deletion is
+        // refused for everyone regardless of privilege level.
+        $perm = new UserPermission;
+        $perm->user_id = $user->id;
+        $perm->solder_users = 1;
+        $perm->save();
+
+        $this->be($user);
+
+        $response = $this->post('/user/delete/'.$user->id);
+        $response->assertRedirect('/user/list');
+        $response->assertSessionHasErrors();
+        $this->assertDatabaseHas('users', ['id' => $user->id]);
+    }
+
+    public function test_user_cannot_reach_self_delete_confirmation(): void
+    {
+        $response = $this->get('/user/delete/'.auth()->user()->id);
         $response->assertRedirect('/user/list');
         $response->assertSessionHasErrors();
     }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -42,6 +42,18 @@ final class UserTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_user_create_get_password_field_hints_new_password(): void
+    {
+        $response = $this->get('/user/create');
+
+        $response->assertOk();
+        $this->assertSame(
+            1,
+            substr_count((string) $response->getContent(), 'autocomplete="new-password"'),
+            'The create form password field must hint new-password so password managers offer to generate one.'
+        );
+    }
+
     public function test_user_create_post_duplicate_email(): void
     {
         $data = [
@@ -88,6 +100,28 @@ final class UserTest extends TestCase
         $response = $this->get('/user/edit/'.$user->id);
 
         $response->assertOk();
+    }
+
+    public function test_user_edit_get_password_fields_hint_new_password(): void
+    {
+        $user = User::firstOrFail();
+
+        $response = $this->get('/user/edit/'.$user->id);
+
+        $response->assertOk();
+
+        $content = (string) $response->getContent();
+
+        $this->assertSame(
+            2,
+            substr_count($content, 'autocomplete="new-password"'),
+            'Both edit form password fields must hint new-password so password managers offer to generate one.'
+        );
+        $this->assertSame(
+            1,
+            substr_count($content, 'autocomplete="current-password"'),
+            'The confirm password modal must hint current-password so password managers offer the existing one.'
+        );
     }
 
     public function test_user_edit_post_duplicate_email(): void


### PR DESCRIPTION
## Summary

- prevent delegated user administrators from granting permissions they do not hold or taking over more privileged accounts
- require the acting user's current password for password changes and reject malformed password input before hashing
- normalize login throttle keys, move successful-login side effects to the Login event, and defer the GitHub update check
- isolate the development Compose project and make every documented development command select compose.dev.yml explicitly

## Testing

- `docker compose -f compose.dev.yml build solder`
- `docker compose -f compose.dev.yml exec -T solder php artisan test --compact tests/Unit/AuthTest.php tests/Unit/AuthorizationTest.php tests/Unit/UserTest.php`

The selected authentication and authorization suites pass with 100 tests and 269 assertions.