### PR TITLE
fix: preserve the last superadmin

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -129,11 +129,10 @@ class UserController extends Controller
 
         return DB::transaction(function () use ($actor, $user) {
             /* Update User Permissions */
-            if ($actor->permission->solder_full || $actor->permission->solder_users) {
+            if (Request::boolean('permissions-present')
+                && ($actor->permission->solder_full || $actor->permission->solder_users)) {
                 $perm = $user->permission;
-                $updatesFullAccess = Request::has('solder-full') || Request::boolean('edit-user');
-                $removesFullAccess = $updatesFullAccess
-                    && $perm->solder_full
+                $removesFullAccess = $perm->solder_full
                     && $actor->can('grant-permission', 'solder_full')
                     && ! \request()->boolean('solder-full');
 
@@ -223,7 +222,9 @@ class UserController extends Controller
             $perm = new UserPermission;
             $perm->user_id = $user->id;
 
-            $this->applyGrantablePermissions($perm, Auth::user());
+            if (Request::boolean('permissions-present')) {
+                $this->applyGrantablePermissions($perm, Auth::user());
+            }
 
             $perm->save();
 
@@ -376,12 +377,6 @@ class UserController extends Controller
     private function applyGrantablePermissions(UserPermission $perm, User $actor): void
     {
         foreach (UserPermission::GRANTABLE_FIELDS as $column => $field) {
-            if ($column === 'solder_full'
-                && ! Request::has($field)
-                && ! Request::boolean('edit-user')) {
-                continue;
-            }
-
             if ($actor->can('grant-permission', $column)) {
                 $perm->{$column} = \request()->boolean($field);
             }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -125,30 +125,57 @@ class UserController extends Controller
             return redirect('user/edit/'.$user_id)->withErrors($validation->messages());
         }
 
-        $user->email = Request::input('email');
-        $user->username = Request::input('username');
-        if (Request::input('password1')) {
-            $user->password = Request::input('password1');
-        }
+        $actor = Auth::user();
 
-        /* Update User Permissions */
-        if (Auth::user()->permission->solder_full || Auth::user()->permission->solder_users) {
-            $perm = $user->permission;
+        return DB::transaction(function () use ($actor, $user) {
+            /* Update User Permissions */
+            if ($actor->permission->solder_full || $actor->permission->solder_users) {
+                $perm = $user->permission;
+                $updatesFullAccess = Request::has('solder-full') || Request::boolean('edit-user');
+                $removesFullAccess = $updatesFullAccess
+                    && $perm->solder_full
+                    && $actor->can('grant-permission', 'solder_full')
+                    && ! \request()->boolean('solder-full');
 
-            $this->applyGrantablePermissions($perm, Auth::user(), (int) $user->id === 1);
+                if ($removesFullAccess) {
+                    $superadmins = UserPermission::query()
+                        ->where('solder_full', true)
+                        ->orderBy('id')
+                        ->lockForUpdate()
+                        ->get(['id', 'user_id']);
 
-            $perm->save();
-        }
+                    $hasOtherSuperadmin = $superadmins->contains(
+                        fn (UserPermission $permission): bool => (int) $permission->user_id !== (int) $user->id
+                    );
 
-        // Security logging
-        $user->updated_by_user_id = Auth::user()->id;
-        $user->updated_by_ip = Request::ip();
+                    if (! $hasOtherSuperadmin) {
+                        return redirect('user/edit/'.$user->id)->withErrors([
+                            'solder-full' => 'At least one user must retain full Solder access.',
+                        ]);
+                    }
+                }
 
-        $user->save();
+                $this->applyGrantablePermissions($perm, $actor);
 
-        $redirect = Auth::id() === $user->id ? 'user/edit/'.$user->id : 'user/list';
+                $perm->save();
+            }
 
-        return redirect($redirect)->with('success', 'User edited successfully!');
+            $user->email = Request::input('email');
+            $user->username = Request::input('username');
+            if (Request::input('password1')) {
+                $user->password = Request::input('password1');
+            }
+
+            // Security logging
+            $user->updated_by_user_id = $actor->id;
+            $user->updated_by_ip = Request::ip();
+
+            $user->save();
+
+            $redirect = $actor->id === $user->id ? 'user/edit/'.$user->id : 'user/list';
+
+            return redirect($redirect)->with('success', 'User edited successfully!');
+        });
     }
 
     public function getCreate()
@@ -196,7 +223,7 @@ class UserController extends Controller
             $perm = new UserPermission;
             $perm->user_id = $user->id;
 
-            $this->applyGrantablePermissions($perm, Auth::user(), false);
+            $this->applyGrantablePermissions($perm, Auth::user());
 
             $perm->save();
 
@@ -346,17 +373,18 @@ class UserController extends Controller
      * permissions they hold themselves; permissions they lack are left at the
      * target's existing value. Only a solder_full user may grant anything.
      */
-    private function applyGrantablePermissions(UserPermission $perm, User $actor, bool $isOriginalAdmin): void
+    private function applyGrantablePermissions(UserPermission $perm, User $actor): void
     {
         foreach (UserPermission::GRANTABLE_FIELDS as $column => $field) {
+            if ($column === 'solder_full'
+                && ! Request::has($field)
+                && ! Request::boolean('edit-user')) {
+                continue;
+            }
+
             if ($actor->can('grant-permission', $column)) {
                 $perm->{$column} = \request()->boolean($field);
             }
-        }
-
-        // The original admin (user 1) is always a superadmin.
-        if ($isOriginalAdmin) {
-            $perm->solder_full = true;
         }
 
         $perm->modpacks = $this->grantableModpacks($actor);

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -14,7 +14,6 @@
 
             <form action="{{ url()->current() }}" method="post" accept-charset="UTF-8">
                 @csrf
-                <input type="hidden" name="edit-user" value="1">
 
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
                     {{-- Left column: Account details --}}
@@ -48,6 +47,7 @@
 
                     {{-- Right column: Permissions --}}
                     <div>
+                        <input type="hidden" name="permissions-present" value="1">
                         <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Permissions</h3>
                         <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
                             Please select the level of access this user will be given. The "Solderwide" permission is

--- a/resources/views/user/edit.blade.php
+++ b/resources/views/user/edit.blade.php
@@ -26,7 +26,6 @@
 
             <form action="{{ url()->current() }}" method="post" accept-charset="UTF-8">
                 @csrf
-                <input type="hidden" name="edit-user" value="1">
 
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
                     {{-- Left column: Account details --}}
@@ -94,6 +93,7 @@
                     {{-- Right column: Permissions --}}
                     <div>
                         @if (Auth::user()->permission->solder_full || Auth::user()->permission->solder_users)
+                            <input type="hidden" name="permissions-present" value="1">
                             <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Permissions</h3>
                             <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
                                 Please select the level of access this user will be given. The "Solderwide" permission

--- a/tests/Unit/AuthorizationTest.php
+++ b/tests/Unit/AuthorizationTest.php
@@ -287,6 +287,7 @@ final class AuthorizationTest extends TestCase
     {
         $user = $this->createUserWithPermissions();
         $this->actingAs($user)->post('/user/edit/'.$user->id, [
+            'permissions-present' => '1',
             'email' => $user->email,
             'username' => $user->username,
             'solder-full' => 'on',
@@ -443,6 +444,7 @@ final class AuthorizationTest extends TestCase
         $actor = $this->createUserWithPermissions(['solder_users' => true, 'mods_manage' => true]);
 
         $this->actingAs($actor)->post('/user/create', [
+            'permissions-present' => '1',
             'username' => 'delegated',
             'email' => 'delegated@example.com',
             'password' => 'B3sTp@ss',
@@ -467,6 +469,7 @@ final class AuthorizationTest extends TestCase
         $target = $this->createUserWithPermissions(['mods_manage' => true]);
 
         $this->actingAs($actor)->post('/user/edit/'.$target->id, [
+            'permissions-present' => '1',
             'username' => $target->username,
             'email' => $target->email,
             'mod-manage' => 'on',
@@ -485,6 +488,7 @@ final class AuthorizationTest extends TestCase
         $actor = $this->createUserWithPermissions(['solder_users' => true, 'mods_manage' => true]);
 
         $this->actingAs($actor)->post('/user/edit/'.$actor->id, [
+            'permissions-present' => '1',
             'username' => $actor->username,
             'email' => $actor->email,
             'manage-users' => 'on',
@@ -511,6 +515,7 @@ final class AuthorizationTest extends TestCase
         $actor->load('permission');
 
         $this->actingAs($actor)->post('/user/create', [
+            'permissions-present' => '1',
             'username' => 'scoped',
             'email' => 'scoped@example.com',
             'password' => 'B3sTp@ss',
@@ -551,6 +556,7 @@ final class AuthorizationTest extends TestCase
         $admin = User::find(1); // solder_full
 
         $this->actingAs($admin)->post('/user/create', [
+            'permissions-present' => '1',
             'username' => 'fullgrant',
             'email' => 'fullgrant@example.com',
             'password' => 'B3sTp@ss',

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -174,6 +174,9 @@ final class UserTest extends TestCase
     public function test_user_edit_post(): void
     {
         $user = User::firstOrFail();
+        $user->permission->solder_users = true;
+        $user->permission->mods_manage = true;
+        $user->permission->save();
 
         $data = [
             'email' => 'admin2@example.com',
@@ -183,6 +186,11 @@ final class UserTest extends TestCase
         $response = $this->post('/user/edit/'.$user->id, $data);
         $response->assertRedirect('/user/edit/'.$user->id);
         $response->assertSessionHas('success');
+
+        $user->refresh();
+        $this->assertTrue((bool) $user->permission->solder_full);
+        $this->assertTrue((bool) $user->permission->solder_users);
+        $this->assertTrue((bool) $user->permission->mods_manage);
     }
 
     public function test_non_original_last_superadmin_cannot_demote_self(): void
@@ -205,7 +213,7 @@ final class UserTest extends TestCase
         $this->post('/user/delete/1')->assertSessionHas('success');
 
         $response = $this->post('/user/edit/'.$user->id, [
-            'edit-user' => '1',
+            'permissions-present' => '1',
             'email' => 'changed@example.com',
             'username' => $user->username,
         ]);
@@ -236,7 +244,7 @@ final class UserTest extends TestCase
         $permission->save();
 
         $response = $this->post('/user/edit/'.$admin->id, [
-            'edit-user' => '1',
+            'permissions-present' => '1',
             'email' => $admin->email,
             'username' => $admin->username,
         ]);
@@ -273,7 +281,7 @@ final class UserTest extends TestCase
         $this->be($manager);
 
         $response = $this->post('/user/edit/'.$target->id, [
-            'edit-user' => '1',
+            'permissions-present' => '1',
             'email' => $target->email,
             'username' => $target->username,
         ]);
@@ -550,6 +558,7 @@ final class UserTest extends TestCase
             'email' => 'test-sadmin@example.com',
             'username' => 'sadmin',
             'password' => 'B3sT3Re4p@ss',
+            'permissions-present' => '1',
             'solder-full' => '1',
         ];
 

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -185,6 +185,107 @@ final class UserTest extends TestCase
         $response->assertSessionHas('success');
     }
 
+    public function test_non_original_last_superadmin_cannot_demote_self(): void
+    {
+        $user = User::unguarded(fn () => User::create([
+            'email' => 'remaining-admin@example.com',
+            'username' => 'remaining-admin',
+            'password' => 'password',
+            'created_ip' => '127.0.0.1',
+            'last_ip' => '127.0.0.1',
+            'created_by_user_id' => 1,
+        ]));
+
+        $permission = new UserPermission;
+        $permission->user_id = $user->id;
+        $permission->solder_full = true;
+        $permission->save();
+
+        $this->be($user);
+        $this->post('/user/delete/1')->assertSessionHas('success');
+
+        $response = $this->post('/user/edit/'.$user->id, [
+            'edit-user' => '1',
+            'email' => 'changed@example.com',
+            'username' => $user->username,
+        ]);
+
+        $response->assertRedirect('/user/edit/'.$user->id);
+        $response->assertSessionHasErrors('solder-full');
+
+        $user->refresh();
+        $this->assertSame('remaining-admin@example.com', $user->email);
+        $this->assertTrue((bool) $user->permission->solder_full);
+    }
+
+    public function test_user_one_can_be_demoted_when_another_superadmin_exists(): void
+    {
+        $admin = User::findOrFail(1);
+        $otherAdmin = User::unguarded(fn () => User::create([
+            'email' => 'other-admin@example.com',
+            'username' => 'other-admin',
+            'password' => 'password',
+            'created_ip' => '127.0.0.1',
+            'last_ip' => '127.0.0.1',
+            'created_by_user_id' => 1,
+        ]));
+
+        $permission = new UserPermission;
+        $permission->user_id = $otherAdmin->id;
+        $permission->solder_full = true;
+        $permission->save();
+
+        $response = $this->post('/user/edit/'.$admin->id, [
+            'edit-user' => '1',
+            'email' => $admin->email,
+            'username' => $admin->username,
+        ]);
+
+        $response->assertRedirect('/user/edit/'.$admin->id);
+        $response->assertSessionHasNoErrors();
+        $response->assertSessionHas('success');
+
+        $admin->refresh();
+        $this->assertFalse((bool) $admin->permission->solder_full);
+        $this->assertTrue((bool) $otherAdmin->permission->solder_full);
+    }
+
+    public function test_editing_non_admin_user_one_does_not_promote_them(): void
+    {
+        $target = User::findOrFail(1);
+        $target->permission->solder_full = false;
+        $target->permission->save();
+
+        $manager = User::unguarded(fn () => User::create([
+            'email' => 'manager@example.com',
+            'username' => 'manager',
+            'password' => 'password',
+            'created_ip' => '127.0.0.1',
+            'last_ip' => '127.0.0.1',
+            'created_by_user_id' => 1,
+        ]));
+
+        $permission = new UserPermission;
+        $permission->user_id = $manager->id;
+        $permission->solder_users = true;
+        $permission->save();
+
+        $this->be($manager);
+
+        $response = $this->post('/user/edit/'.$target->id, [
+            'edit-user' => '1',
+            'email' => $target->email,
+            'username' => $target->username,
+        ]);
+
+        $response->assertRedirect('/user/list');
+        $response->assertSessionHasNoErrors();
+        $response->assertSessionHas('success');
+
+        $target->refresh();
+        $this->assertFalse((bool) $target->permission->solder_full);
+    }
+
     public function test_password_change_requires_current_password(): void
     {
         $user = User::firstOrFail();


### PR DESCRIPTION
## Summary

- replace the user-ID-1 superadmin override with a role-based last-superadmin invariant
- lock current superadmin rows during demotion and reject the update unless another superadmin remains
- submit an explicit `permissions-present` marker only when the permission section is rendered, so profile/password-only requests preserve every permission while full forms retain unchecked-checkbox revocation semantics
- persist profile and permission changes atomically and cover non-ID-1 last administrators, legitimate demotion of user 1, ordinary accounts assigned ID 1, and marker-free profile edits

## Testing

- `docker compose -f compose.dev.yml exec -T solder ./vendor/bin/pint --dirty --format agent`
- `docker compose -f compose.dev.yml exec -T solder php artisan test --compact tests/Unit/UserTest.php`
- `docker compose -f compose.dev.yml exec -T solder php artisan test --compact tests/Unit/AuthorizationTest.php`
- `docker compose -f compose.dev.yml exec -T solder php artisan test --compact tests/Unit/AuthTest.php tests/Unit/AuthorizationTest.php tests/Unit/UserTest.php`

The combined authentication, authorization, and user suites pass with 103 tests and 290 assertions.